### PR TITLE
Support button message responses

### DIFF
--- a/config/opendialog.php
+++ b/config/opendialog.php
@@ -7,6 +7,3 @@ return [
 
     'LOG_DGRAPH_QUERIES' => env("LOG_DGRAPH_QUERIES", false)
 ];
-
-
-

--- a/src/ActionEngine/Actions/ExampleAction.php
+++ b/src/ActionEngine/Actions/ExampleAction.php
@@ -27,7 +27,7 @@ class ExampleAction extends BaseAction
     public function perform(ActionInput $actionInput): ActionResult
     {
         $fullName = $actionInput->getAttributeBag()->getAttribute('first_name')->getValue() .
-        $actionInput->getAttributeBag()->getAttribute('last_name')->getValue();
+            $actionInput->getAttributeBag()->getAttribute('last_name')->getValue();
 
         $fullNameAttribute = new StringAttribute('full_name', $fullName);
 

--- a/src/ActionEngine/Actions/ExampleAction.php
+++ b/src/ActionEngine/Actions/ExampleAction.php
@@ -27,7 +27,7 @@ class ExampleAction extends BaseAction
     public function perform(ActionInput $actionInput): ActionResult
     {
         $fullName = $actionInput->getAttributeBag()->getAttribute('first_name')->getValue() .
-            $actionInput->getAttributeBag()->getAttribute('last_name')->getValue();
+        $actionInput->getAttributeBag()->getAttribute('last_name')->getValue();
 
         $fullNameAttribute = new StringAttribute('full_name', $fullName);
 

--- a/src/ContextEngine/config/opendialog-contextengine.php
+++ b/src/ContextEngine/config/opendialog-contextengine.php
@@ -2,18 +2,19 @@
 
 return [
     'supported_attributes' => [
-        'ei_type' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'context' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'operation' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'id' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
         'attribute_name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
         'attribute_value' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'first_name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'last_name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'full_name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'external_id' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'button_value' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'context' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'ei_type' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
         'email' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'external_id' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'first_name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'full_name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'id' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'last_name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'operation' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
         'timestamp' => \OpenDialogAi\Core\Attribute\IntAttribute::class,
 
         // Intents

--- a/src/InterpreterEngine/Interpreters/CallbackInterpreter.php
+++ b/src/InterpreterEngine/Interpreters/CallbackInterpreter.php
@@ -49,7 +49,7 @@ class CallbackInterpreter extends BaseInterpreter
                     $intent = new Intent($this->supportedCallbacks[$utterance->getCallbackId()]);
                     $intent->setConfidence(1);
 
-                    if ($value = $utterance->getValue()) {
+                    if ($utterance->getType() == 'button_response' && $value = $utterance->getValue()) {
                         $attribute = new StringAttribute('button_value', $value);
                         Log::debug(sprintf(
                             'Adding attribute %s with value %s to intent.',

--- a/src/InterpreterEngine/Interpreters/CallbackInterpreter.php
+++ b/src/InterpreterEngine/Interpreters/CallbackInterpreter.php
@@ -5,6 +5,7 @@ namespace OpenDialogAi\InterpreterEngine\Interpreters;
 
 
 use Illuminate\Support\Facades\Log;
+use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\UtteranceInterface;
@@ -47,6 +48,16 @@ class CallbackInterpreter extends BaseInterpreter
                 if (array_key_exists($callbackId, $this->supportedCallbacks)) {
                     $intent = new Intent($this->supportedCallbacks[$utterance->getCallbackId()]);
                     $intent->setConfidence(1);
+
+                    if ($value = $utterance->getValue()) {
+                        $attribute = new StringAttribute('button_value', $value);
+                        Log::debug(sprintf(
+                            'Adding attribute %s with value %s to intent.',
+                            $attribute->getId(),
+                            $attribute->getValue()
+                        ));
+                        $intent->addAttribute($attribute);
+                    }
                     return [$intent];
                 }
             }

--- a/src/SensorEngine/Http/Requests/IncomingWebchatMessage.php
+++ b/src/SensorEngine/Http/Requests/IncomingWebchatMessage.php
@@ -30,9 +30,9 @@ class IncomingWebchatMessage extends FormRequest
             // The content array is required for all messages.
             'content' => 'required|array',
             // Validate the message type.
-            'content.type' => 'in:chat_open,text,trigger',
+            'content.type' => 'in:button_response,chat_open,text,trigger',
             // The callback_id is required for chat_opens.
-            'content.data.callback_id' => 'required_if:content.type,==,chat_open|string',
+            'content.data.callback_id' => 'required_if:content.type,in:button_response,chat_open|string',
             // The user data array is required for chat_opens.
             'content.data.user' => 'required_if:content.type,==,chat_open|array',
         ];

--- a/src/SensorEngine/Sensors/WebchatSensor.php
+++ b/src/SensorEngine/Sensors/WebchatSensor.php
@@ -67,6 +67,21 @@ class WebchatSensor extends BaseSensor
                 return $utterance;
                 break;
 
+            case 'button_response':
+                Log::debug('Received webchat button_response message.');
+                $utterance = new WebchatTriggerUtterance();
+                $utterance->setCallbackId($request['content']['data']['callback_id']);
+                Log::debug(sprintf('Set callback id as %s', $utterance->getCallbackId()));
+                $utterance->setUserId($request['user_id']);
+                if (isset($request['content']['user'])) {
+                    $utterance->setUser($this->createUser($request['content']['user']));
+                }
+                if (isset($request['content']['data']['value'])) {
+                    $utterance->setValue($request['content']['data']['value']);
+                }
+                return $utterance;
+                break;
+
             default:
                 Log::debug("Received unknown webchat message type {$request['content']['type']}.");
                 throw new UtteranceUnknownMessageType('Unknown Webchat Message Type.');

--- a/src/SensorEngine/Sensors/WebchatSensor.php
+++ b/src/SensorEngine/Sensors/WebchatSensor.php
@@ -8,10 +8,11 @@ use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\Exceptions\UtteranceUnknownMessageType;
 use OpenDialogAi\Core\Utterances\User;
 use OpenDialogAi\Core\Utterances\UtteranceInterface;
+use OpenDialogAi\Core\Utterances\Webchat\WebchatButtonResponseUtterance;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatChatOpenUtterance;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatTextUtterance;
-use OpenDialogAi\SensorEngine\BaseSensor;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatTriggerUtterance;
+use OpenDialogAi\SensorEngine\BaseSensor;
 
 class WebchatSensor extends BaseSensor
 {
@@ -69,7 +70,7 @@ class WebchatSensor extends BaseSensor
 
             case 'button_response':
                 Log::debug('Received webchat button_response message.');
-                $utterance = new WebchatTriggerUtterance();
+                $utterance = new WebchatButtonResponseUtterance();
                 $utterance->setCallbackId($request['content']['data']['callback_id']);
                 Log::debug(sprintf('Set callback id as %s', $utterance->getCallbackId()));
                 $utterance->setUserId($request['user_id']);

--- a/src/Utterances/BaseUtterance.php
+++ b/src/Utterances/BaseUtterance.php
@@ -42,15 +42,15 @@ abstract class BaseUtterance implements UtteranceInterface
     }
 
     /**
-     * Returns the type of utterance. Classes that extend this class can set their own type by defining a type constant
+     * Returns the utterance platform. Classes that extend this class can set their own type by defining a type constant
      *
      * @return string
      * @throws UtteranceTypeNotSetException
      */
-    public function getType(): string
+    public function getPlatform(): string
     {
         if (static::PLATFORM === self::PLATFORM) {
-            throw new UtteranceTypeNotSetException('Utterance platform has not been set');
+            throw new UtterancePlatformNotSetException('Utterance platform has not been set');
         }
 
         return static::PLATFORM;
@@ -62,10 +62,10 @@ abstract class BaseUtterance implements UtteranceInterface
      * @return string
      * @throws UtterancePlatformNotSetException
      */
-    public function getPlatform(): string
+    public function getType(): string
     {
         if (static::TYPE === self::TYPE) {
-            throw new UtterancePlatformNotSetException('Utterance platform has not been set');
+            throw new UtteranceTypeNotSetException('Utterance platform has not been set');
         }
 
         return static::TYPE;

--- a/src/Utterances/BaseUtterance.php
+++ b/src/Utterances/BaseUtterance.php
@@ -45,7 +45,7 @@ abstract class BaseUtterance implements UtteranceInterface
      * Returns the utterance platform. Classes that extend this class can set their own type by defining a type constant
      *
      * @return string
-     * @throws UtteranceTypeNotSetException
+     * @throws UtterancePlatformNotSetException
      */
     public function getPlatform(): string
     {
@@ -60,7 +60,7 @@ abstract class BaseUtterance implements UtteranceInterface
      * Returns the type of utterance. Classes that extend this class can set their own type by defining a type constant
      *
      * @return string
-     * @throws UtterancePlatformNotSetException
+     * @throws UtteranceTypeNotSetException
      */
     public function getType(): string
     {

--- a/src/Utterances/ButtonResponseUtterance.php
+++ b/src/Utterances/ButtonResponseUtterance.php
@@ -9,6 +9,8 @@ use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
  */
 abstract class ButtonResponseUtterance extends BaseUtterance
 {
+    const TYPE = 'button_response';
+
     /**
      * @inheritdoc
      */

--- a/src/Utterances/ButtonResponseUtterance.php
+++ b/src/Utterances/ButtonResponseUtterance.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace OpenDialogAi\Core\Utterances;
+
+use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
+
+/**
+ * Button response utterances do not include text
+ */
+abstract class ButtonResponseUtterance extends BaseUtterance
+{
+    /**
+     * @inheritdoc
+     */
+    public function getText(): string
+    {
+        throw new FieldNotSupported('Text field is not supported by button response utterances');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setText(string $text): void
+    {
+        throw new FieldNotSupported('Text field is not supported by button response utterances');
+    }
+}

--- a/src/Utterances/Webchat/WebchatButtonResponseUtterance.php
+++ b/src/Utterances/Webchat/WebchatButtonResponseUtterance.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace OpenDialogAi\Core\Utterances\Webchat;
+
+use OpenDialogAi\Core\Utterances\ButtonResponseUtterance;
+
+class WebchatButtonResponseUtterance extends ButtonResponseUtterance
+{
+    const PLATFORM = 'webchat';
+}


### PR DESCRIPTION
Testing steps I took:

* Added the following message to the no match message template:
```xml
<button-message>
  <text>Do you love me?</text>
  <button>
    <text>Yes</text>
    <callback>yes_love</callback>
  </button>
  <button>
    <text>No</text>
    <callback>no_love</callback>
  </button>
</button-message>
```
* Added `'yes_love' => 'intent.bdo.yesLove',` to the supported callbacks in BDO-OD's interpreter_engine.php
* Added this conversation:
```yaml
conversation:
  id: love
  scenes:
    opening_scene:
      intents:
        - u: 
            i: intent.bdo.yesLove
        - b: 
            i: intent.bdo.positive_response
            completes: true
```
* Added the `intent.bdo.positive_response` intent, with this message template:
```xml
<message>
  <text-message>yay!</text-message>
</message>
```

Adding a negative response is left as an exercise for the reader.
