### PR TITLE
uses intval when returning values from the int attribute so users can…

### DIFF
--- a/src/Attribute/IntAttribute.php
+++ b/src/Attribute/IntAttribute.php
@@ -20,7 +20,7 @@ class IntAttribute extends BasicAttribute
 
     public function getValue()
     {
-        return parent::getValue();
+        return intval($this->value);
     }
 
     /**


### PR DESCRIPTION
… always assume an integer