### PR TITLE
Updates getNextPossibleBotIntents to handle more complex conversations

### DIFF
--- a/src/Conversation/Participant.php
+++ b/src/Conversation/Participant.php
@@ -69,6 +69,16 @@ class Participant extends Node
     /**
      * @return \Ds\Map
      */
+    public function getAllIntentsSaidInOrder()
+    {
+        return $this->getAllIntentsSaid()->sorted(function (Node $a, Node $b) {
+            return $a->getAttributeValue(Model::ORDER) > $b->getAttributeValue(Model::ORDER);
+        });
+    }
+
+    /**
+     * @return \Ds\Map
+     */
     public function getAllIntentsListenedFor()
     {
         $allIntentsSaid = new Map();

--- a/src/Conversation/Scene.php
+++ b/src/Conversation/Scene.php
@@ -152,26 +152,20 @@ class Scene extends NodeWithConditions
      */
     public function getNextPossibleBotIntents(Intent $currentIntent): Map
     {
-        // If the current intent is in this scene, use its order. If not (because it's said across scenes), we use 0
-        // because the new scene's ordering is independent of the previous scene.
+        // If the current intent is in this scene, use its order. If it's said across scenes, we use 0.
         $currentOrder = $this->hasIntent($currentIntent) ? $currentIntent->getOrder() : 0;
-
 
         /** @var Intent $previousKeptIntent */
         $previousKeptIntent = null;
 
         $intents = $this->getIntentsSaidByBotInOrder()->filter(
             function ($key, Intent $possibleIntent) use ($currentOrder, &$previousKeptIntent) {
-                // Intents are considered sequential if its the first intent or if it's order directly follows the
-                // previously kept intent
+                // Intents are considered sequential if its the first or if it directly follows the previously kept intent
                 $intentsAreSequential = is_null($previousKeptIntent)
                     || $previousKeptIntent->getOrder() + 1 == $possibleIntent->getOrder();
 
-                // Keep the intent if its order is higher and the previous bot intent was sequential
-                $shouldKeep = $possibleIntent->getOrder() > $currentOrder
-                    && $intentsAreSequential;
+                $shouldKeep = $possibleIntent->getOrder() > $currentOrder && $intentsAreSequential;
 
-                // Set previousIntent to determine whether there is a block of sequential bot intents
                 if ($shouldKeep) {
                     $previousKeptIntent = $possibleIntent;
                 }

--- a/src/Conversation/Scene.php
+++ b/src/Conversation/Scene.php
@@ -93,6 +93,16 @@ class Scene extends NodeWithConditions
         return $this->bot->getAllIntentsSaid();
     }
 
+    public function getIntentsSaidByUserInOrder()
+    {
+        return $this->user->getAllIntentsSaidInOrder();
+    }
+
+    public function getIntentsSaidByBotInOrder()
+    {
+        return $this->bot->getAllIntentsSaidInOrder();
+    }
+
     public function getIntentsListenedByUser()
     {
         return $this->user->getAllIntentsListenedFor();
@@ -142,19 +152,33 @@ class Scene extends NodeWithConditions
      */
     public function getNextPossibleBotIntents(Intent $currentIntent): Map
     {
-        $intents = $this->getIntentsSaidByBot()->filter( function ($key, Intent $possibleIntent) use ($currentIntent) {
-            if (!$this->hasIntent($currentIntent)) {
-                // TODO We have moved scenes, not able to determine the correct ordering
-                return true;
-            }
+        // If the current intent is in this scene, use its order. If not (because it's said across scenes), we use 0
+        // because the new scene's ordering is independent of the previous scene.
+        $currentOrder = $this->hasIntent($currentIntent) ? $currentIntent->getOrder() : 0;
 
-            /* @var Intent $value */
-            if ($possibleIntent->getOrder() === $currentIntent->getOrder() + 1) {
-                return true;
-            }
 
-            return false;
-        });
+        /** @var Intent $previousKeptIntent */
+        $previousKeptIntent = null;
+
+        $intents = $this->getIntentsSaidByBotInOrder()->filter(
+            function ($key, Intent $possibleIntent) use ($currentOrder, &$previousKeptIntent) {
+                // Intents are considered sequential if its the first intent or if it's order directly follows the
+                // previously kept intent
+                $intentsAreSequential = is_null($previousKeptIntent)
+                    || $previousKeptIntent->getOrder() + 1 == $possibleIntent->getOrder();
+
+                // Keep the intent if its order is higher and the previous bot intent was sequential
+                $shouldKeep = $possibleIntent->getOrder() > $currentOrder
+                    && $intentsAreSequential;
+
+                // Set previousIntent to determine whether there is a block of sequential bot intents
+                if ($shouldKeep) {
+                    $previousKeptIntent = $possibleIntent;
+                }
+
+                return $shouldKeep;
+            }
+        );
 
         return $intents;
     }

--- a/tests/Feature/NextIntentDetectionTest.php
+++ b/tests/Feature/NextIntentDetectionTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace OpenDialogAi\Core\Tests\Feature;
+
+use OpenDialogAi\ContextEngine\Facades\ContextService;
+use OpenDialogAi\Core\Controllers\OpenDialogController;
+use OpenDialogAi\Core\Tests\TestCase;
+use OpenDialogAi\Core\Tests\Utils\UtteranceGenerator;
+
+class NextIntentDetectionTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->publishConversation($this->conversation4());
+    }
+
+    public function testComplexConversation()
+    {
+        $this->setSupportedCallbacks([
+            'hello_bot' => 'hello_bot',
+            'ask_weather' => 'ask_weather',
+            'respond_weather' => 'respond_weather'
+        ]);
+
+        $openDialogController = resolve(OpenDialogController::class);
+
+        $this->publishConversation($this->getTestConversation());
+
+        $conversationContext = ContextService::getConversationContext();
+
+        // Start the conversation
+        $utterance = UtteranceGenerator::generateChatOpenUtterance('hello_bot');
+        $openDialogController->runConversation($utterance);
+        $this->assertEquals($conversationContext->getAttributeValue('current_conversation'), 'test_conversation');
+        $this->assertEquals($conversationContext->getAttributeValue('interpreted_intent'), 'hello_bot');
+        $this->assertEquals($conversationContext->getAttributeValue('current_scene'), 'opening_scene');
+        $this->assertEquals($conversationContext->getAttributeValue('next_intent'), 'hello_user');
+
+        // Ask about the weather - this should keep the user in the opening scene
+        $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('ask_weather', $utterance->getUser()));
+        $this->assertEquals($conversationContext->getAttributeValue('interpreted_intent'), 'ask_weather');
+        $this->assertEquals($conversationContext->getAttributeValue('current_conversation'), 'test_conversation');
+        $this->assertEquals($conversationContext->getAttributeValue('current_scene'), 'opening_scene');
+        $this->assertEquals($conversationContext->getAttributeValue('next_intent'), 'send_weather');
+
+        // Respond to the weather
+        $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('respond_weather', $utterance->getUser()));
+        $this->assertEquals($conversationContext->getAttributeValue('interpreted_intent'), 'respond_weather');
+        $this->assertEquals($conversationContext->getAttributeValue('current_conversation'), 'test_conversation');
+        $this->assertEquals($conversationContext->getAttributeValue('current_scene'), 'opening_scene');
+        $this->assertEquals($conversationContext->getAttributeValue('next_intent'), 'finish');
+    }
+
+    public function testSaidAcrossScene()
+    {
+        $this->setSupportedCallbacks([
+            'hello_bot' => 'hello_bot',
+            'ask_chat' => 'ask_chat',
+            'how_are_you' => 'how_are_you',
+        ]);
+
+        $openDialogController = resolve(OpenDialogController::class);
+
+        $this->publishConversation($this->getTestConversation());
+
+        $conversationContext = ContextService::getConversationContext();
+
+        // Ask to chat - this should keep the user in the opening scene
+        $utterance = UtteranceGenerator::generateChatOpenUtterance('hello_bot');
+        $openDialogController->runConversation($utterance);
+        $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('ask_chat', $utterance->getUser()));
+        $this->assertEquals($conversationContext->getAttributeValue('interpreted_intent'), 'ask_chat');
+        $this->assertEquals($conversationContext->getAttributeValue('current_conversation'), 'test_conversation');
+        $this->assertEquals($conversationContext->getAttributeValue('current_scene'), 'opening_scene');
+        $this->assertEquals($conversationContext->getAttributeValue('next_intent'), 'start_chat');
+
+        // Respond to the weather
+        $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('how_are_you', $utterance->getUser()));
+        $this->assertEquals($conversationContext->getAttributeValue('interpreted_intent'), 'how_are_you');
+        $this->assertEquals($conversationContext->getAttributeValue('current_conversation'), 'test_conversation');
+        $this->assertEquals($conversationContext->getAttributeValue('current_scene'), 'scene2');
+        $this->assertEquals($conversationContext->getAttributeValue('next_intent'), 'doing_dandy');
+    }
+
+    public function getTestConversation()
+    {
+        return <<<EOT
+conversation:
+  id: test_conversation
+  scenes:
+    opening_scene:
+      intents:
+        - u: 
+            i: hello_bot
+        - b: 
+            i: hello_user
+        - u:
+            i: ask_weather
+        - u: 
+            i: ask_chat
+            scene: scene2
+        - b:
+            i: send_weather
+        - b:
+            i: send_weather2
+        - u:
+            i: respond_weather
+        - b:
+            i: finish
+            completes: true
+    scene2:
+      intents:
+        - b: 
+            i: start_chat
+        - u: 
+            i: how_are_you
+        - b: 
+            i: doing_dandy
+            completes: true
+EOT;
+    }
+}

--- a/tests/Unit/Conversation/ParticipantTest.php
+++ b/tests/Unit/Conversation/ParticipantTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace OpenDialogAi\Core\Tests\Unit\Conversation;
+
+use OpenDialogAi\Core\Conversation\ConversationManager;
+use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Tests\TestCase;
+
+class ParticipantTest extends TestCase
+{
+    const CONVERSATION = 'test_conversation';
+    const OPENING_SCENE = 'opening_scene';
+    const NEXT_SCENE = 'next_scene';
+
+    const INTENT_USER_TO_BOT_1 = 'say_hello';
+    const INTENT_BOT_TO_USER_2 = 'send_hello';
+    const INTENT_USER_TO_BOT_3 = 'ask_question';
+    const INTENT_USER_TO_BOT_4 = 'something_new';
+    const INTENT_BOT_TO_USER_4 = 'send_answer';
+    const INTENT_USER_TO_BOT_5 = 'say_goodbye';
+    const INTENT_BOT_TO_USER_6 = 'send_goodbye';
+    const INTENT_BOT_TO_USER_7 = 'say_goodbye2';
+
+    /**
+     * @var Intent
+     */
+    private $intent1;
+
+    /**
+     * @var Intent
+     */
+    private $intent2;
+
+    /**
+     * @var Intent
+     */
+    private $intent3;
+
+    /**
+     * @var Intent
+     */
+    private $intent4;
+
+    /**
+     * @var Intent
+     */
+    private $intent5;
+
+    /**
+     * @var Intent
+     */
+    private $intent6;
+
+    /**
+     * @var Intent
+     */
+    private $intent7;
+
+    public function setupConversationWithOneScene()
+    {
+        $cm = new ConversationManager(self::CONVERSATION);
+        $cm->createScene(self::OPENING_SCENE, true);
+
+        $this->intent1 = new Intent(self::INTENT_USER_TO_BOT_1);
+        $this->intent1->setOrderAttribute(1);
+
+        $this->intent2 = new Intent(self::INTENT_BOT_TO_USER_2);
+        $this->intent2->setOrderAttribute(2);
+
+        $this->intent3 = new Intent(self::INTENT_USER_TO_BOT_3);
+        $this->intent3->setOrderAttribute(3);
+
+        $this->intent4 = new Intent(self::INTENT_BOT_TO_USER_4);
+        $this->intent4->setOrderAttribute(4);
+
+        $this->intent5 = new Intent(self::INTENT_USER_TO_BOT_5);
+        $this->intent5->setOrderAttribute(5);
+
+        $this->intent6 = new Intent(self::INTENT_BOT_TO_USER_6, true);
+        $this->intent6->setOrderAttribute(6);
+
+        $cm->userSaysToBot(self::OPENING_SCENE, $this->intent1, 1)
+            ->botSaysToUser(self::OPENING_SCENE, $this->intent2, 2)
+            ->userSaysToBot(self::OPENING_SCENE, $this->intent3, 3)
+            ->botSaysToUser(self::OPENING_SCENE, $this->intent4, 4)
+            ->userSaysToBot(self::OPENING_SCENE, $this->intent5, 5)
+            ->botSaysToUser(self::OPENING_SCENE, $this->intent6, 6);
+
+        return $cm;
+    }
+
+    public function setupConversationWithTwoScenes()
+    {
+        $cm = new ConversationManager(self::CONVERSATION);
+        $cm->createScene(self::OPENING_SCENE, true);
+        $cm->createScene(self::NEXT_SCENE, false);
+
+        $this->intent1 = new Intent(self::INTENT_USER_TO_BOT_1);
+        $this->intent1->setOrderAttribute(1);
+
+        $this->intent2 = new Intent(self::INTENT_BOT_TO_USER_2);
+        $this->intent2->setOrderAttribute(2);
+
+        $this->intent3 = new Intent(self::INTENT_USER_TO_BOT_3);
+        $this->intent3->setOrderAttribute(3);
+
+        $this->intent4 = new Intent(self::INTENT_USER_TO_BOT_4);
+        $this->intent4->setOrderAttribute(4);
+
+        $this->intent5 = new Intent(self::INTENT_BOT_TO_USER_4, true);
+        $this->intent5->setOrderAttribute(1);
+
+        $this->intent6 = new Intent(self::INTENT_BOT_TO_USER_6);
+        $this->intent6->setOrderAttribute(5);
+
+        $this->intent7 = new Intent(self::INTENT_BOT_TO_USER_7, true);
+        $this->intent7->setOrderAttribute(2);
+
+        $cm->userSaysToBot(self::OPENING_SCENE, $this->intent1, 1)
+            ->botSaysToUser(self::OPENING_SCENE, $this->intent2, 2)
+            ->userSaysToBot(self::OPENING_SCENE, $this->intent3, 3)
+            ->userSaysToBotAcrossScenes(self::OPENING_SCENE, self::NEXT_SCENE, $this->intent4, 4)
+            ->botSaysToUser(self::NEXT_SCENE, $this->intent5, 1)
+            ->botSaysToUser(self::OPENING_SCENE, $this->intent6, 5)
+            ->botSaysToUser(self::NEXT_SCENE, $this->intent7, 2);
+
+        return $cm;
+    }
+
+    public function testGetAllIntentsSaidInOrderWithOneScene()
+    {
+        $cm = $this->setupConversationWithOneScene();
+        $openingScene = $cm->getScene(self::OPENING_SCENE);
+
+        $user = $openingScene->getUser();
+        $userIntents = $user->getAllIntentsSaidInOrder();
+        $this->assertEquals($this->intent1->getId(), $userIntents->skip(0)->value->getId());
+        $this->assertEquals($this->intent3->getId(), $userIntents->skip(1)->value->getId());
+        $this->assertEquals($this->intent5->getId(), $userIntents->skip(2)->value->getId());
+
+        $bot = $openingScene->getBot();
+        $botIntents = $bot->getAllIntentsSaidInOrder();
+        $this->assertEquals($this->intent2->getId(), $botIntents->skip(0)->value->getId());
+        $this->assertEquals($this->intent4->getId(), $botIntents->skip(1)->value->getId());
+        $this->assertEquals($this->intent6->getId(), $botIntents->skip(2)->value->getId());
+    }
+
+    public function testGetAllIntentsSaidInOrderWithTwoScenes()
+    {
+        $cm = $this->setupConversationWithTwoScenes();
+        $openingScene = $cm->getScene(self::OPENING_SCENE);
+        $nextScene = $cm->getScene(self::NEXT_SCENE);
+
+        $user = $openingScene->getUser();
+        $userIntents = $user->getAllIntentsSaidInOrder();
+        $this->assertEquals($this->intent1->getId(), $userIntents->skip(0)->value->getId());
+        $this->assertEquals($this->intent3->getId(), $userIntents->skip(1)->value->getId());
+        $this->assertEquals($this->intent4->getId(), $userIntents->skip(2)->value->getId());
+
+        $bot = $openingScene->getBot();
+        $botIntents = $bot->getAllIntentsSaidInOrder();
+        $this->assertEquals($this->intent2->getId(), $botIntents->skip(0)->value->getId());
+        $this->assertEquals($this->intent6->getId(), $botIntents->skip(1)->value->getId());
+
+        $bot = $nextScene->getBot();
+        $botIntents = $bot->getAllIntentsSaidInOrder();
+        $this->assertEquals($this->intent5->getId(), $botIntents->skip(0)->value->getId());
+        $this->assertEquals($this->intent7->getId(), $botIntents->skip(1)->value->getId());
+    }
+}

--- a/tests/Unit/Conversation/ScenesTest.php
+++ b/tests/Unit/Conversation/ScenesTest.php
@@ -30,62 +30,62 @@ class ScenesTest extends TestCase
     /**
      * @var Intent
      */
-    private $_intent1;
+    private $intent1;
 
     /**
      * @var Intent
      */
-    private $_intent2;
+    private $intent2;
 
     /**
      * @var Intent
      */
-    private $_intent3;
+    private $intent3;
 
     /**
      * @var Intent
      */
-    private $_intent4;
+    private $intent4;
 
     /**
      * @var Intent
      */
-    private $_intent5;
+    private $intent5;
 
     /**
      * @var Intent
      */
-    private $_intent6;
+    private $intent6;
 
     /**
      * @var Intent
      */
-    private $_intent7;
+    private $intent7;
 
     /**
      * @var Intent
      */
-    private $_intent8;
+    private $intent8;
 
     /**
      * @var Intent
      */
-    private $_intent9;
+    private $intent9;
 
     /**
      * @var Intent
      */
-    private $_intent10;
+    private $intent10;
 
     /**
      * @var Intent
      */
-    private $_intent11;
+    private $intent11;
 
     /**
      * @var Intent
      */
-    private $_intent12;
+    private $intent12;
 
     public function setupConversation()
     {
@@ -96,54 +96,54 @@ class ScenesTest extends TestCase
         $cm->createScene(self::LATEST_NEWS_SCENE, false);
 
         // Add an intent from one participant to the other
-        $this->_intent1 = new Intent(self::INTENT_USER_TO_BOT_1);
-        $this->_intent1->setOrderAttribute(1);
+        $this->intent1 = new Intent(self::INTENT_USER_TO_BOT_1);
+        $this->intent1->setOrderAttribute(1);
 
-        $this->_intent2 = new Intent(self::INTENT_BOT_TO_USER_2);
-        $this->_intent2->setOrderAttribute(2);
+        $this->intent2 = new Intent(self::INTENT_BOT_TO_USER_2);
+        $this->intent2->setOrderAttribute(2);
 
-        $this->_intent3 = new Intent(self::INTENT_USER_TO_BOT_3);
-        $this->_intent3->setOrderAttribute(3);
+        $this->intent3 = new Intent(self::INTENT_USER_TO_BOT_3);
+        $this->intent3->setOrderAttribute(3);
 
-        $this->_intent4 = new Intent(self::INTENT_USER_TO_BOT_4);
-        $this->_intent4->setOrderAttribute(4);
+        $this->intent4 = new Intent(self::INTENT_USER_TO_BOT_4);
+        $this->intent4->setOrderAttribute(4);
 
-        $this->_intent5 = new Intent(self::INTENT_BOT_TO_USER_5);
-        $this->_intent5->setOrderAttribute(1);
+        $this->intent5 = new Intent(self::INTENT_BOT_TO_USER_5);
+        $this->intent5->setOrderAttribute(1);
 
-        $this->_intent6 = new Intent(self::INTENT_BOT_TO_USER_7);
-        $this->_intent6->setOrderAttribute(2);
+        $this->intent6 = new Intent(self::INTENT_BOT_TO_USER_7);
+        $this->intent6->setOrderAttribute(2);
 
-        $this->_intent7 = new Intent(self::INTENT_USER_TO_BOT_6);
-        $this->_intent7->setOrderAttribute(3);
+        $this->intent7 = new Intent(self::INTENT_USER_TO_BOT_6);
+        $this->intent7->setOrderAttribute(3);
 
-        $this->_intent8 = new Intent(self::INTENT_BOT_TO_USER_8, true);
-        $this->_intent8->setOrderAttribute(4);
+        $this->intent8 = new Intent(self::INTENT_BOT_TO_USER_8, true);
+        $this->intent8->setOrderAttribute(4);
 
-        $this->_intent9 = new Intent(self::INTENT_BOT_TO_USER_9);
-        $this->_intent9->setOrderAttribute(6);
+        $this->intent9 = new Intent(self::INTENT_BOT_TO_USER_9);
+        $this->intent9->setOrderAttribute(6);
 
-        $this->_intent10 = new Intent(self::INTENT_BOT_TO_USER_10);
-        $this->_intent10->setOrderAttribute(7);
+        $this->intent10 = new Intent(self::INTENT_BOT_TO_USER_10);
+        $this->intent10->setOrderAttribute(7);
 
-        $this->_intent11 = new Intent(self::INTENT_USER_TO_BOT_11);
-        $this->_intent11->setOrderAttribute(8);
+        $this->intent11 = new Intent(self::INTENT_USER_TO_BOT_11);
+        $this->intent11->setOrderAttribute(8);
 
-        $this->_intent12 = new Intent(self::INTENT_BOT_TO_USER_12, true);
-        $this->_intent12->setOrderAttribute(9);
+        $this->intent12 = new Intent(self::INTENT_BOT_TO_USER_12, true);
+        $this->intent12->setOrderAttribute(9);
 
-        $cm->userSaysToBot(self::OPENING_SCENE, $this->_intent1, 1)
-            ->botSaysToUser(self::OPENING_SCENE, $this->_intent2, 2)
-            ->userSaysToBot(self::OPENING_SCENE, $this->_intent3, 3)
-            ->userSaysToBotAcrossScenes(self::OPENING_SCENE, self::LATEST_NEWS_SCENE, $this->_intent4, 4)
-            ->botSaysToUser(self::LATEST_NEWS_SCENE, $this->_intent5, 1)
-            ->botSaysToUser(self::LATEST_NEWS_SCENE, $this->_intent6, 2)
-            ->userSaysToBot(self::LATEST_NEWS_SCENE, $this->_intent7, 3)
-            ->botSaysToUser(self::LATEST_NEWS_SCENE, $this->_intent8, 4)
-            ->botSaysToUser(self::OPENING_SCENE, $this->_intent9, 6)
-            ->botSaysToUser(self::OPENING_SCENE, $this->_intent10, 7)
-            ->userSaysToBot(self::OPENING_SCENE, $this->_intent11, 8)
-            ->botSaysToUser(self::OPENING_SCENE, $this->_intent12, 9);
+        $cm->userSaysToBot(self::OPENING_SCENE, $this->intent1, 1)
+            ->botSaysToUser(self::OPENING_SCENE, $this->intent2, 2)
+            ->userSaysToBot(self::OPENING_SCENE, $this->intent3, 3)
+            ->userSaysToBotAcrossScenes(self::OPENING_SCENE, self::LATEST_NEWS_SCENE, $this->intent4, 4)
+            ->botSaysToUser(self::LATEST_NEWS_SCENE, $this->intent5, 1)
+            ->botSaysToUser(self::LATEST_NEWS_SCENE, $this->intent6, 2)
+            ->userSaysToBot(self::LATEST_NEWS_SCENE, $this->intent7, 3)
+            ->botSaysToUser(self::LATEST_NEWS_SCENE, $this->intent8, 4)
+            ->botSaysToUser(self::OPENING_SCENE, $this->intent9, 6)
+            ->botSaysToUser(self::OPENING_SCENE, $this->intent10, 7)
+            ->userSaysToBot(self::OPENING_SCENE, $this->intent11, 8)
+            ->botSaysToUser(self::OPENING_SCENE, $this->intent12, 9);
 
         return $cm;
     }
@@ -172,21 +172,21 @@ class ScenesTest extends TestCase
         $latestNewsScene = $cm->getScene(self::LATEST_NEWS_SCENE);
 
         // Test that to begin with it returns just intent2
-        $possibleIntents = $openingScene->getNextPossibleBotIntents($this->_intent1);
+        $possibleIntents = $openingScene->getNextPossibleBotIntents($this->intent1);
         $this->assertEquals(1, $possibleIntents->count());
-        $this->assertEquals($this->_intent2->getId(), $possibleIntents->first()->value->getId());
+        $this->assertEquals($this->intent2->getId(), $possibleIntents->first()->value->getId());
 
         // Test that it returns the correct intents when the current intent is intent3 and that they are in the right order
-        $possibleIntents = $openingScene->getNextPossibleBotIntents($this->_intent3);
+        $possibleIntents = $openingScene->getNextPossibleBotIntents($this->intent3);
         $this->assertEquals(2, $possibleIntents->count());
-        $this->assertEquals($this->_intent9->getId(), $possibleIntents->first()->value->getId());
-        $this->assertEquals($this->_intent10->getId(), $possibleIntents->get(self::INTENT_BOT_TO_USER_10)->getId());
+        $this->assertEquals($this->intent9->getId(), $possibleIntents->first()->value->getId());
+        $this->assertEquals($this->intent10->getId(), $possibleIntents->get(self::INTENT_BOT_TO_USER_10)->getId());
 
         // Test that it returns the correct intents when the current intent is said across scenes and that they are in the right order
-        $possibleIntents = $latestNewsScene->getNextPossibleBotIntents($this->_intent4);
+        $possibleIntents = $latestNewsScene->getNextPossibleBotIntents($this->intent4);
         $this->assertEquals(2, $possibleIntents->count());
-        $this->assertEquals($this->_intent5->getId(), $possibleIntents->first()->value->getId());
-        $this->assertEquals($this->_intent6->getId(), $possibleIntents->get(self::INTENT_BOT_TO_USER_7)->getId());
+        $this->assertEquals($this->intent5->getId(), $possibleIntents->first()->value->getId());
+        $this->assertEquals($this->intent6->getId(), $possibleIntents->get(self::INTENT_BOT_TO_USER_7)->getId());
     }
 
 }

--- a/tests/Unit/Conversation/ScenesTest.php
+++ b/tests/Unit/Conversation/ScenesTest.php
@@ -4,8 +4,8 @@
 namespace OpenDialogAi\Core\Tests\Unit\Conversation;
 
 use Ds\Map;
-use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\ConversationManager;
+use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Tests\TestCase;
 
 class ScenesTest extends TestCase
@@ -15,6 +15,78 @@ class ScenesTest extends TestCase
     const LATEST_NEWS_SCENE = 'test_latest_news_scene';
     const CONTINUE_WITH_AUDIT_SCENE = 'test_continue_with_audit_scene';
 
+    const INTENT_USER_TO_BOT_1 = 'intent.core.hi';
+    const INTENT_BOT_TO_USER_2 = 'intent.core.welcome_and_choose';
+    const INTENT_USER_TO_BOT_3 = 'intent.core.continue_with_audit';
+    const INTENT_USER_TO_BOT_4 = 'intent.core.get_the_latest_news';
+    const INTENT_BOT_TO_USER_5 = 'intent.core.here_are_the_news';
+    const INTENT_USER_TO_BOT_6 = 'intent.core.accept_news';
+    const INTENT_BOT_TO_USER_7 = 'intent.core.complete_news';
+    const INTENT_BOT_TO_USER_8 = 'intent.core.complete_news2';
+    const INTENT_BOT_TO_USER_9 = 'intent.core.here_is_the_audit';
+    const INTENT_BOT_TO_USER_10 = 'intent.core.here_is_the_audit2';
+    const INTENT_USER_TO_BOT_11 = 'intent.core.accept_audit';
+    const INTENT_BOT_TO_USER_12 = 'intent.core.complete_audit';
+    /**
+     * @var Intent
+     */
+    private $_intent1;
+
+    /**
+     * @var Intent
+     */
+    private $_intent2;
+
+    /**
+     * @var Intent
+     */
+    private $_intent3;
+
+    /**
+     * @var Intent
+     */
+    private $_intent4;
+
+    /**
+     * @var Intent
+     */
+    private $_intent5;
+
+    /**
+     * @var Intent
+     */
+    private $_intent6;
+
+    /**
+     * @var Intent
+     */
+    private $_intent7;
+
+    /**
+     * @var Intent
+     */
+    private $_intent8;
+
+    /**
+     * @var Intent
+     */
+    private $_intent9;
+
+    /**
+     * @var Intent
+     */
+    private $_intent10;
+
+    /**
+     * @var Intent
+     */
+    private $_intent11;
+
+    /**
+     * @var Intent
+     */
+    private $_intent12;
+
     public function setupConversation()
     {
         // Create a conversation manager and setup a conversation
@@ -22,7 +94,56 @@ class ScenesTest extends TestCase
 
         $cm->createScene(self::OPENING_SCENE, true);
         $cm->createScene(self::LATEST_NEWS_SCENE, false);
-        $cm->createScene(self::CONTINUE_WITH_AUDIT_SCENE, false);
+
+        // Add an intent from one participant to the other
+        $this->_intent1 = new Intent(self::INTENT_USER_TO_BOT_1);
+        $this->_intent1->setOrderAttribute(1);
+
+        $this->_intent2 = new Intent(self::INTENT_BOT_TO_USER_2);
+        $this->_intent2->setOrderAttribute(2);
+
+        $this->_intent3 = new Intent(self::INTENT_USER_TO_BOT_3);
+        $this->_intent3->setOrderAttribute(3);
+
+        $this->_intent4 = new Intent(self::INTENT_USER_TO_BOT_4);
+        $this->_intent4->setOrderAttribute(4);
+
+        $this->_intent5 = new Intent(self::INTENT_BOT_TO_USER_5);
+        $this->_intent5->setOrderAttribute(1);
+
+        $this->_intent6 = new Intent(self::INTENT_BOT_TO_USER_7);
+        $this->_intent6->setOrderAttribute(2);
+
+        $this->_intent7 = new Intent(self::INTENT_USER_TO_BOT_6);
+        $this->_intent7->setOrderAttribute(3);
+
+        $this->_intent8 = new Intent(self::INTENT_BOT_TO_USER_8, true);
+        $this->_intent8->setOrderAttribute(4);
+
+        $this->_intent9 = new Intent(self::INTENT_BOT_TO_USER_9);
+        $this->_intent9->setOrderAttribute(6);
+
+        $this->_intent10 = new Intent(self::INTENT_BOT_TO_USER_10);
+        $this->_intent10->setOrderAttribute(7);
+
+        $this->_intent11 = new Intent(self::INTENT_USER_TO_BOT_11);
+        $this->_intent11->setOrderAttribute(8);
+
+        $this->_intent12 = new Intent(self::INTENT_BOT_TO_USER_12, true);
+        $this->_intent12->setOrderAttribute(9);
+
+        $cm->userSaysToBot(self::OPENING_SCENE, $this->_intent1, 1)
+            ->botSaysToUser(self::OPENING_SCENE, $this->_intent2, 2)
+            ->userSaysToBot(self::OPENING_SCENE, $this->_intent3, 3)
+            ->userSaysToBotAcrossScenes(self::OPENING_SCENE, self::LATEST_NEWS_SCENE, $this->_intent4, 4)
+            ->botSaysToUser(self::LATEST_NEWS_SCENE, $this->_intent5, 1)
+            ->botSaysToUser(self::LATEST_NEWS_SCENE, $this->_intent6, 2)
+            ->userSaysToBot(self::LATEST_NEWS_SCENE, $this->_intent7, 3)
+            ->botSaysToUser(self::LATEST_NEWS_SCENE, $this->_intent8, 4)
+            ->botSaysToUser(self::OPENING_SCENE, $this->_intent9, 6)
+            ->botSaysToUser(self::OPENING_SCENE, $this->_intent10, 7)
+            ->userSaysToBot(self::OPENING_SCENE, $this->_intent11, 8)
+            ->botSaysToUser(self::OPENING_SCENE, $this->_intent12, 9);
 
         return $cm;
     }
@@ -30,7 +151,6 @@ class ScenesTest extends TestCase
     public function testAddOpeningScene()
     {
         $cm = $this->setupConversation();
-        /* @var Conversation $conversation */
         $conversation = $cm->getConversation();
 
         $this->assertTrue($conversation->getId() == self::CONVERSATION);
@@ -43,6 +163,30 @@ class ScenesTest extends TestCase
 
         $this->assertTrue(count($openingScenes) == 1);
         $this->assertTrue($openingScenes->first()->toArray()['value']->getId() == self::OPENING_SCENE);
+    }
+
+    public function testGetNextPossibleBotIntents()
+    {
+        $cm = $this->setupConversation();
+        $openingScene = $cm->getScene(self::OPENING_SCENE);
+        $latestNewsScene = $cm->getScene(self::LATEST_NEWS_SCENE);
+
+        // Test that to begin with it returns just intent2
+        $possibleIntents = $openingScene->getNextPossibleBotIntents($this->_intent1);
+        $this->assertEquals(1, $possibleIntents->count());
+        $this->assertEquals($this->_intent2->getId(), $possibleIntents->first()->value->getId());
+
+        // Test that it returns the correct intents when the current intent is intent3 and that they are in the right order
+        $possibleIntents = $openingScene->getNextPossibleBotIntents($this->_intent3);
+        $this->assertEquals(2, $possibleIntents->count());
+        $this->assertEquals($this->_intent9->getId(), $possibleIntents->first()->value->getId());
+        $this->assertEquals($this->_intent10->getId(), $possibleIntents->get(self::INTENT_BOT_TO_USER_10)->getId());
+
+        // Test that it returns the correct intents when the current intent is said across scenes and that they are in the right order
+        $possibleIntents = $latestNewsScene->getNextPossibleBotIntents($this->_intent4);
+        $this->assertEquals(2, $possibleIntents->count());
+        $this->assertEquals($this->_intent5->getId(), $possibleIntents->first()->value->getId());
+        $this->assertEquals($this->_intent6->getId(), $possibleIntents->get(self::INTENT_BOT_TO_USER_7)->getId());
     }
 
 }


### PR DESCRIPTION
This PR fixes #188 by updating `Scene.getNextPossibleBotIntents`. Methods have also been added to the `Scene` and `Participant` classes to get intents sorted by their orders. `getNextPossibleBotIntents` has been updated to use these new methods, filter through the ordered bot intents and remove those that are lower than the current intent's order and which are not within a sequential block after the current intent.

The decision of which intent to choose is still left with the ConversationEngine. `getNextPossibleBotIntents` will return an ordered map containing either the sole next bot intent or a block of sequential next bot intents. Tests have also been added to check and demonstrate this functionality.