### PR TITLE
Adds support for simple and most prebuilt LUIS entity types

### DIFF
--- a/src/InterpreterEngine/Luis/LuisEntity.php
+++ b/src/InterpreterEngine/Luis/LuisEntity.php
@@ -134,6 +134,7 @@ class LuisEntity
     }
 
     /**
+     * Returns a constant representing the structure (or existence) of the entity's resolution object
      * @param $entity
      * @return int
      */

--- a/src/InterpreterEngine/tests/LuisEntityTest.php
+++ b/src/InterpreterEngine/tests/LuisEntityTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace OpenDialogAi\Core\InterpreterEngine\tests;
+
+use OpenDialogAi\Core\Tests\TestCase;
+use OpenDialogAi\InterpreterEngine\Luis\LuisEntity;
+
+class LuisEntityTest extends TestCase
+{
+    public function testExtractValues()
+    {
+        $simpleEntity = <<<EOT
+{
+    "entity": "LGW",
+    "type": "airport",
+    "startIndex": 10,
+    "endIndex": 12
+}
+EOT;
+        $simpleLUISEntity = new LuisEntity(json_decode($simpleEntity));
+        $this->assertEquals(1, count($simpleLUISEntity->getResolutionValues()));
+        $this->assertEquals("LGW", $simpleLUISEntity->getResolutionValues()[0]);
+
+        $prebuiltEntity = <<<EOT
+{
+    "entity": "test@example.com",
+    "type": "builtin.email",
+    "startIndex": 10,
+    "endIndex": 25,
+    "resolution": {
+        "value": "test@example.com"
+    }
+}
+EOT;
+        $prebuiltLUISEntity = new LuisEntity(json_decode($prebuiltEntity));
+        $this->assertEquals(1, count($prebuiltLUISEntity->getResolutionValues()));
+        $this->assertEquals("test@example.com", $prebuiltLUISEntity->getResolutionValues()[0]);
+
+        $listEntity = <<<EOT
+{
+    "entity": "six foot",
+    "type": "height",
+    "startIndex": 10,
+    "endIndex": 17,
+    "resolution": {
+        "values": [
+            "tall"
+        ]
+    }
+}
+EOT;
+        $listLUISEntity = new LuisEntity(json_decode($listEntity));
+        $this->assertEquals(1, count($listLUISEntity->getResolutionValues()));
+        $this->assertEquals("tall", $listLUISEntity->getResolutionValues()[0]);
+
+        $listEntityWithManyResolutions = <<<EOT
+{
+    "entity": "something ambiguous",
+    "type": "some_type",
+    "startIndex": 10,
+    "endIndex": 28,
+    "resolution": {
+        "values": [
+            "value_1",
+            "value_2",
+            "value_3"
+        ]
+    }
+}
+EOT;
+        $listLUISEntityWithManyResolutions = new LuisEntity(json_decode($listEntityWithManyResolutions));
+        $this->assertEquals(3, count($listLUISEntityWithManyResolutions->getResolutionValues()));
+        $this->assertEquals("value_1", $listLUISEntityWithManyResolutions->getResolutionValues()[0]);
+        $this->assertEquals("value_2", $listLUISEntityWithManyResolutions->getResolutionValues()[1]);
+        $this->assertEquals("value_3", $listLUISEntityWithManyResolutions->getResolutionValues()[2]);
+    }
+}


### PR DESCRIPTION
This PR furthers LUIS entity type support from just list entities to include [simple entities](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/reference-entity-simple) and most of the [prebuilt entity types](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-concept-entity-types#prebuilt-entity). The fallback for these few unsupported prebuilt types is to resolve the entity using the entity string (which is also the case for simple entity types).

The updates anticipate three potential structures of an entity object within a LUIS response:

1. When no `resolution` property exists, get the entity value from the `entity` property.
2. When a `resolution` property exists and it contains a `values` property, get the entity value from the first item in the list.
3. When a `resolution` property exists and it contains a `value` property, get the entity value from there.
