### PR TITLE
Extract entity value from the query string for simple entities

### DIFF
--- a/src/InterpreterEngine/Luis/LuisEntity.php
+++ b/src/InterpreterEngine/Luis/LuisEntity.php
@@ -8,6 +8,12 @@ class LuisEntity
     private const ONE_RESOLUTION_VALUE = 1;
     private const MANY_RESOLUTION_VALUES = 2;
 
+    /**
+     * The user's input
+     * @var string
+     */
+    private $query;
+
     /* @var string */
     private $type;
 
@@ -41,10 +47,10 @@ class LuisEntity
      */
     private $score;
 
-    public function __construct($entity)
+    public function __construct($entity, $query)
     {
+        $this->query = $query;
         $this->type = $entity->type;
-
         $this->entityString = $entity->entity;
 
         if (isset($entity->startIndex)) {
@@ -57,6 +63,14 @@ class LuisEntity
         if (isset($entity->score)) {
             $this->score = floatval($entity->score);
         }
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getQuery(): ?string
+    {
+        return $this->query;
     }
 
     /**
@@ -125,7 +139,7 @@ class LuisEntity
 
             case self::NO_RESOLUTION_VALUE:
             default:
-                $values[] = $this->entityString;
+                $values[] = $this->extractValueWhenNoResolution();
         }
 
         foreach ($values as $value) {
@@ -149,5 +163,21 @@ class LuisEntity
         }
 
         return self::NO_RESOLUTION_VALUE;
+    }
+
+    /**
+     * Extracts a value when the entity has no resolution value. The value is extracted from the the query if possible
+     * and from the entity string otherwise.
+     * @return string
+     */
+    private function extractValueWhenNoResolution()
+    {
+        $entityValue = $this->getEntityString();
+
+        if (!is_null($this->getQuery()) && !is_null($this->getStartIndex()) && !is_null($this->getEndIndex())) {
+            $entityValue = substr($this->getQuery(), $this->getStartIndex(), 1 + $this->getEndIndex() - $this->getStartIndex());
+        }
+
+        return $entityValue;
     }
 }

--- a/src/InterpreterEngine/Luis/LuisEntity.php
+++ b/src/InterpreterEngine/Luis/LuisEntity.php
@@ -74,49 +74,49 @@ class LuisEntity
     }
 
     /**
-     * @return mixed
+     * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
     /**
-     * @return mixed
+     * @return string
      */
-    public function getEntityString()
+    public function getEntityString(): string
     {
         return $this->entityString;
     }
 
     /**
-     * @return mixed
+     * @return int
      */
-    public function getStartIndex()
+    public function getStartIndex(): int
     {
         return $this->startIndex;
     }
 
     /**
-     * @return mixed
+     * @return int
      */
-    public function getEndIndex()
+    public function getEndIndex(): int
     {
         return $this->endIndex;
     }
 
     /**
-     * @return mixed
+     * @return array
      */
-    public function getResolutionValues()
+    public function getResolutionValues(): array
     {
         return $this->resolutionValues;
     }
 
     /**
-     * @return mixed
+     * @return float
      */
-    public function getScore()
+    public function getScore(): float
     {
         return $this->score;
     }
@@ -170,7 +170,7 @@ class LuisEntity
      * and from the entity string otherwise.
      * @return string
      */
-    private function extractValueWhenNoResolution()
+    private function extractValueWhenNoResolution(): string
     {
         $entityValue = $this->getEntityString();
 

--- a/src/InterpreterEngine/Luis/LuisResponse.php
+++ b/src/InterpreterEngine/Luis/LuisResponse.php
@@ -36,14 +36,14 @@ class LuisResponse
     private function createEntities($entities)
     {
         foreach ($entities as $entity) {
-            $this->entities[] = new LuisEntity($entity);
+            $this->entities[] = new LuisEntity($entity, $this->getQuery());
         }
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getQuery(): string
+    public function getQuery(): ?string
     {
         return $this->query;
     }

--- a/src/InterpreterEngine/tests/LuisClientTest.php
+++ b/src/InterpreterEngine/tests/LuisClientTest.php
@@ -78,7 +78,7 @@ EOT;
 }
 EOT;
 
-        $entity = new LuisEntity(json_decode($rawLuisIntent));
+        $entity = new LuisEntity(json_decode($rawLuisIntent), "I am in zurich");
         $this->assertEquals('SwissCanton', $entity->getType());
         $this->assertEquals('zurich', $entity->getEntityString());
         $this->assertEquals(8, $entity->getStartIndex());

--- a/src/InterpreterEngine/tests/LuisEntityTest.php
+++ b/src/InterpreterEngine/tests/LuisEntityTest.php
@@ -13,26 +13,38 @@ class LuisEntityTest extends TestCase
 {
     "entity": "LGW",
     "type": "airport",
-    "startIndex": 10,
-    "endIndex": 12
+    "startIndex": 20,
+    "endIndex": 22
 }
 EOT;
-        $simpleLUISEntity = new LuisEntity(json_decode($simpleEntity));
+        $simpleLUISEntity = new LuisEntity(json_decode($simpleEntity), "Book me a flight to LGW");
         $this->assertEquals(1, count($simpleLUISEntity->getResolutionValues()));
         $this->assertEquals("LGW", $simpleLUISEntity->getResolutionValues()[0]);
+
+        $simpleEntityWithCaseSensitivity = <<<EOT
+{
+    "entity": "john",
+    "type": "built.personName",
+    "startIndex": 0,
+    "endIndex": 3
+}
+EOT;
+        $simpleLUISEntity = new LuisEntity(json_decode($simpleEntityWithCaseSensitivity), "John");
+        $this->assertEquals(1, count($simpleLUISEntity->getResolutionValues()));
+        $this->assertEquals("John", $simpleLUISEntity->getResolutionValues()[0]);
 
         $prebuiltEntity = <<<EOT
 {
     "entity": "test@example.com",
     "type": "builtin.email",
-    "startIndex": 10,
-    "endIndex": 25,
+    "startIndex": 12,
+    "endIndex": 27,
     "resolution": {
         "value": "test@example.com"
     }
 }
 EOT;
-        $prebuiltLUISEntity = new LuisEntity(json_decode($prebuiltEntity));
+        $prebuiltLUISEntity = new LuisEntity(json_decode($prebuiltEntity), "My email is test@example.com");
         $this->assertEquals(1, count($prebuiltLUISEntity->getResolutionValues()));
         $this->assertEquals("test@example.com", $prebuiltLUISEntity->getResolutionValues()[0]);
 
@@ -40,8 +52,8 @@ EOT;
 {
     "entity": "six foot",
     "type": "height",
-    "startIndex": 10,
-    "endIndex": 17,
+    "startIndex": 5,
+    "endIndex": 12,
     "resolution": {
         "values": [
             "tall"
@@ -49,7 +61,7 @@ EOT;
     }
 }
 EOT;
-        $listLUISEntity = new LuisEntity(json_decode($listEntity));
+        $listLUISEntity = new LuisEntity(json_decode($listEntity), "I am six foot tall");
         $this->assertEquals(1, count($listLUISEntity->getResolutionValues()));
         $this->assertEquals("tall", $listLUISEntity->getResolutionValues()[0]);
 
@@ -57,8 +69,8 @@ EOT;
 {
     "entity": "something ambiguous",
     "type": "some_type",
-    "startIndex": 10,
-    "endIndex": 28,
+    "startIndex": 0,
+    "endIndex": 18,
     "resolution": {
         "values": [
             "value_1",
@@ -68,7 +80,7 @@ EOT;
     }
 }
 EOT;
-        $listLUISEntityWithManyResolutions = new LuisEntity(json_decode($listEntityWithManyResolutions));
+        $listLUISEntityWithManyResolutions = new LuisEntity(json_decode($listEntityWithManyResolutions), "something ambiguous");
         $this->assertEquals(3, count($listLUISEntityWithManyResolutions->getResolutionValues()));
         $this->assertEquals("value_1", $listLUISEntityWithManyResolutions->getResolutionValues()[0]);
         $this->assertEquals("value_2", $listLUISEntityWithManyResolutions->getResolutionValues()[1]);


### PR DESCRIPTION
This PR amends the LuisEntity class to extract the entity value from the query string for simple (or unknown) LUIS entities. This allows simple LUIS entities to retain any user-inputted cases, as LUIS converts all input to lowercase.