### PR TITLE
Only return opening intents when searching for a new conversation

### DIFF
--- a/src/ConversationEngine/ConversationStore/DGraphQueries/AllOpeningIntents.php
+++ b/src/ConversationEngine/ConversationStore/DGraphQueries/AllOpeningIntents.php
@@ -12,6 +12,9 @@ use OpenDialogAi\Core\Graph\DGraph\DGraphQuery;
 
 class AllOpeningIntents extends DGraphQuery
 {
+    /**
+     * @var array
+     */
     private $conversations;
 
     public function __construct(DGraphClient $client)
@@ -66,10 +69,22 @@ class AllOpeningIntents extends DGraphQuery
             ]);
 
         $response = $client->query($this);
-        $this->conversations = $response->getData();
+        $this->setConversations($response->getData());
     }
 
-    public function getData()
+    private function setConversations($conversations): void
+    {
+        if (is_null($conversations) || count($conversations) < 1) {
+            $this->conversations = [];
+        } else {
+            $this->conversations = $conversations;
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getConversations(): array
     {
         return $this->conversations;
     }
@@ -82,7 +97,7 @@ class AllOpeningIntents extends DGraphQuery
     public function getIntents()
     {
         $intents = new Map();
-        foreach ($this->conversations as $conversation) {
+        foreach ($this->getConversations() as $conversation) {
             $conditions = new Map();
 
             if (isset($conversation[Model::HAS_CONDITION])) {

--- a/src/ConversationEngine/tests/AllOpeningIntentsTest.php
+++ b/src/ConversationEngine/tests/AllOpeningIntentsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace OpenDialogAi\ConversationEngine\tests;
+
+use OpenDialogAi\ConversationEngine\ConversationStore\DGraphQueries\AllOpeningIntents;
+use OpenDialogAi\Core\Graph\DGraph\DGraphClient;
+use OpenDialogAi\Core\Tests\TestCase;
+
+class AllOpeningIntentsTest extends TestCase
+{
+    private $dGraph;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->publishConversation($this->conversation1());
+        $this->publishConversation($this->conversation2());
+        $this->publishConversation($this->conversation3());
+        $this->publishConversation($this->conversation4());
+
+        $this->dGraph = app()->make(DGraphClient::class);
+    }
+
+    public function testReturnsSimpleSingleOpeningIntents()
+    {
+        // Test only with conversations that have one user intent in their opening scenes
+        $allOpeningIntents = new AllOpeningIntents($this->dGraph);
+        $openingIntents = $allOpeningIntents->getIntents();
+        $this->assertEquals(4, $openingIntents->count());
+        $this->assertEquals("hello_bot", $openingIntents->skip(0)->value->getIntentId());
+        $this->assertEquals("howdy_bot", $openingIntents->skip(1)->value->getIntentId());
+        $this->assertEquals("top_of_the_morning_bot", $openingIntents->skip(2)->value->getIntentId());
+        $this->assertEquals("intent.core.NoMatch", $openingIntents->skip(3)->value->getIntentId());
+    }
+
+    public function testReturnsComplexSingleOpeningIntents()
+    {
+        // Test with a conversation that has many user intents in the opening scene
+        $complexConversationYaml = <<<EOT
+conversation:
+  id: complex_convo
+  scenes:
+    opening_scene:
+      intents:
+        - u: 
+            i: order_pizza
+        - b: 
+            i: ask_topping
+        - u: 
+            i: send_topping
+        - b: 
+            i: ask_size
+        - u: 
+            i: send_size
+        - b: 
+            i: complete_order
+            completes: true
+EOT;
+        $this->publishConversation($complexConversationYaml);
+
+        $allOpeningIntentsWithComplex = new AllOpeningIntents($this->dGraph);
+        $openingIntents = $allOpeningIntentsWithComplex->getIntents();
+        $this->assertEquals(5, $openingIntents->count());
+        $this->assertEquals("hello_bot", $openingIntents->skip(0)->value->getIntentId());
+        $this->assertEquals("howdy_bot", $openingIntents->skip(1)->value->getIntentId());
+        $this->assertEquals("top_of_the_morning_bot", $openingIntents->skip(2)->value->getIntentId());
+        $this->assertEquals("intent.core.NoMatch", $openingIntents->skip(3)->value->getIntentId());
+        $this->assertEquals("order_pizza", $openingIntents->skip(4)->value->getIntentId());
+    }
+
+    public function testReturnsComplexMultipleOpeningIntents()
+    {
+        // Test with a conversation that has many user intents in the opening scene and many opening user intents
+        $complexConversationYaml = <<<EOT
+conversation:
+  id: complex_convo
+  scenes:
+    opening_scene:
+      intents:
+        - u: 
+            i: order_pizza
+        - u: 
+            i: rate_pizza
+            scene: rate_pizza
+        - b: 
+            i: ask_topping
+        - u: 
+            i: send_topping
+        - b: 
+            i: ask_size
+        - u: 
+            i: send_size
+        - b: 
+            i: complete_order
+            completes: true
+    rate_pizza:
+      intents:
+        - b: 
+            i: ask_rating
+        - b: 
+            i: send_rating
+        - b: 
+            i: complete_rating
+            completes: true
+EOT;
+        $this->publishConversation($complexConversationYaml);
+
+        $allOpeningIntentsWithComplex = new AllOpeningIntents($this->dGraph);
+        $openingIntents = $allOpeningIntentsWithComplex->getIntents();
+        $this->assertEquals(6, $openingIntents->count());
+        $this->assertEquals("hello_bot", $openingIntents->skip(0)->value->getIntentId());
+        $this->assertEquals("howdy_bot", $openingIntents->skip(1)->value->getIntentId());
+        $this->assertEquals("top_of_the_morning_bot", $openingIntents->skip(2)->value->getIntentId());
+        $this->assertEquals("intent.core.NoMatch", $openingIntents->skip(3)->value->getIntentId());
+        $this->assertEquals("order_pizza", $openingIntents->skip(4)->value->getIntentId());
+        $this->assertEquals("rate_pizza", $openingIntents->skip(5)->value->getIntentId());
+    }
+}

--- a/src/ConversationEngine/tests/SceneTest.php
+++ b/src/ConversationEngine/tests/SceneTest.php
@@ -57,7 +57,7 @@ class SceneTest extends TestCase
 
         $this->assertEquals('hello_human', $intent->getId());
 
-        $utterance = UtteranceGenerator::generateChatOpenUtterance('hello_again_bot');
+        $utterance = UtteranceGenerator::generateChatOpenUtterance('hello_again_bot', $utterance->getUser());
 
         /* @var UserContext $userContext ; */
         $userContext = ContextService::createUserContext($utterance);


### PR DESCRIPTION
This PR updates the `AllOpeningIntents.getIntents` method to return only the first user intents from opening scenes. Prior to this PR, the method returns user intents from throughout the opening scene, which is not the desired behaviour.

Returning these additional intents creates the possibility of a user dropping into the middle of a different conversation template instead of being switched to the No Match conversation. An instance when this could occur is if the user enters text and one of the incorrectly returned intents has a Luis Interpreter - the user's text may well match this intent and set it to be the next intent, therefore dropping the user into a new conversation late in its opening scene.

This PR also fixes SceneTest which incorrectly relied on this previous behaviour.