### PR TITLE
Scene conditions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: socat TCP-LISTEN:8080,reuseaddr,fork "EXEC:'docker --tlsverify -H=$DOCKER_HOST --tlscacert=$DOCKER_CERT_PATH/ca.pem --tlscert=$DOCKER_CERT_PATH/cert.pem --tlskey=$DOCKER_CERT_PATH/key.pem exec -i dgraph_server_1 socat STDIO TCP-CONNECT:localhost:8080'"
 
       # run tests!
-      - run: phpdbg -qrr ./vendor/bin/phpunit --coverage-html build/coverage-report -d memory_limit=512M
+      - run: phpdbg -qrr ./vendor/bin/phpunit --coverage-html build/coverage-report -d memory_limit=2048M
 
       - store_artifacts:
           path:  build/coverage-report

--- a/src/Conversation/ConversationManager.php
+++ b/src/Conversation/ConversationManager.php
@@ -195,8 +195,6 @@ class ConversationManager
         $sceneIntent = clone $intent;
         $sceneIntent->setOrderAttribute($order);
 
-        $this->pullConditionsFromScene($endingSceneId, $sceneIntent);
-
         /* @var Scene $startingScene */
         $startingScene = $this->conversation->getScene($startingSceneId);
         $startingScene->userSaysToBotLeadingOutOfScene($sceneIntent);
@@ -221,8 +219,6 @@ class ConversationManager
         /* @var Intent $sceneIntent */
         $sceneIntent = clone $intent;
         $sceneIntent->setOrderAttribute($order);
-
-        $this->pullConditionsFromScene($endingSceneId, $sceneIntent);
 
         /* @var Scene $startingScene */
         $startingScene = $this->conversation->getScene($startingSceneId);
@@ -327,21 +323,5 @@ class ConversationManager
     public function setInstanceOf(Conversation $instanceOf)
     {
         $this->conversation->setInstanceOf($instanceOf);
-    }
-
-    /**
-     * @param $endingSceneId
-     * @param Intent $sceneIntent
-     */
-    private function pullConditionsFromScene($endingSceneId, Intent $sceneIntent): void
-    {
-        $endingScene = $this->getScene($endingSceneId);
-
-        if ($endingScene->hasConditions()) {
-            /** @var Condition $condition */
-            foreach ($endingScene->getConditions() as $condition) {
-                $sceneIntent->addCondition($condition);
-            }
-        }
     }
 }

--- a/src/Conversation/ConversationManager.php
+++ b/src/Conversation/ConversationManager.php
@@ -195,6 +195,8 @@ class ConversationManager
         $sceneIntent = clone $intent;
         $sceneIntent->setOrderAttribute($order);
 
+        $this->pullConditionsFromScene($endingSceneId, $sceneIntent);
+
         /* @var Scene $startingScene */
         $startingScene = $this->conversation->getScene($startingSceneId);
         $startingScene->userSaysToBotLeadingOutOfScene($sceneIntent);
@@ -219,6 +221,8 @@ class ConversationManager
         /* @var Intent $sceneIntent */
         $sceneIntent = clone $intent;
         $sceneIntent->setOrderAttribute($order);
+
+        $this->pullConditionsFromScene($endingSceneId, $sceneIntent);
 
         /* @var Scene $startingScene */
         $startingScene = $this->conversation->getScene($startingSceneId);
@@ -323,5 +327,21 @@ class ConversationManager
     public function setInstanceOf(Conversation $instanceOf)
     {
         $this->conversation->setInstanceOf($instanceOf);
+    }
+
+    /**
+     * @param $endingSceneId
+     * @param Intent $sceneIntent
+     */
+    private function pullConditionsFromScene($endingSceneId, Intent $sceneIntent): void
+    {
+        $endingScene = $this->getScene($endingSceneId);
+
+        if ($endingScene->hasConditions()) {
+            /** @var Condition $condition */
+            foreach ($endingScene->getConditions() as $condition) {
+                $sceneIntent->addCondition($condition);
+            }
+        }
     }
 }

--- a/src/Conversation/Intent.php
+++ b/src/Conversation/Intent.php
@@ -309,15 +309,15 @@ class Intent extends NodeWithConditions
      */
     public function getAllConditions(): Map
     {
-        $intents = new Map();
+        $conditions = new Map();
 
         if ($this->hasConditions()) {
-            $intents = $intents->merge($this->getConditions());
+            $conditions = $conditions->merge($this->getConditions());
         }
 
-        $intents = $intents->merge($this->getConditionsFromDestinationScene());
+        $conditions = $conditions->merge($this->getConditionsFromDestinationScene());
 
-        return $intents;
+        return $conditions;
     }
 
     /**

--- a/src/ConversationBuilder/Conversation.php
+++ b/src/ConversationBuilder/Conversation.php
@@ -3,6 +3,7 @@
 namespace OpenDialogAi\ConversationBuilder;
 
 use Closure;
+use Ds\Set;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -170,6 +171,10 @@ class Conversation extends Model
         foreach ($yaml['scenes'] as $sceneId => $scene) {
             $sceneIsOpeningScene = $sceneId === 'opening_scene';
             $conversationManager->createScene($sceneId, $sceneIsOpeningScene);
+
+            if (!$sceneIsOpeningScene && isset($scene['conditions'])) {
+                $this->addSceneConditions($sceneId, $scene['conditions'], $conversationManager);
+            }
         }
 
         // Now cycle through the scenes again and identifying intents that cut across scenes.
@@ -388,18 +393,10 @@ class Conversation extends Model
         }
 
         if (is_array($conditions)) {
-            foreach ($conditions as $condition) {
-                try {
-                    $conditionObject = $this->createCondition($condition['condition']);
-                    $intentNode->addCondition($conditionObject);
-                } catch (Exception $e) {
-                    Log::debug(
-                        sprintf(
-                            'Could not create condition because: %s',
-                            $e->getMessage()
-                        )
-                    );
-                }
+            $conditionObjects = $this->createConditions($conditions);
+
+            foreach ($conditionObjects as $condition) {
+                $intentNode->addCondition($condition);
             }
         }
 
@@ -412,18 +409,25 @@ class Conversation extends Model
      */
     public function addConversationConditions(array $conditions, ConversationManager $cm)
     {
-        foreach ($conditions as $key => $condition) {
-            try {
-                $conditionObject = $this->createCondition($condition['condition']);
-                $cm->addConditionToConversation($conditionObject);
-            } catch (Exception $e) {
-                Log::debug(
-                    sprintf(
-                        'Could not create condition because: %s',
-                        $e->getMessage()
-                    )
-                );
-            }
+        $conditionObjects = $this->createConditions($conditions);
+
+        foreach ($conditionObjects as $condition) {
+            $cm->addConditionToConversation($condition);
+        }
+    }
+
+    /**
+     * @param $sceneId
+     * @param $conditions
+     * @param ConversationManager $conversationManager
+     */
+    public function addSceneConditions($sceneId, $conditions, ConversationManager $conversationManager)
+    {
+        $conditionObjects = $this->createConditions($conditions);
+        $scene = $conversationManager->getScene($sceneId);
+
+        foreach ($conditionObjects as $condition) {
+            $scene->addCondition($condition);
         }
     }
 
@@ -614,5 +618,29 @@ class Conversation extends Model
         $conversationStore = app()->make(ConversationStoreInterface::class);
 
         return $conversationStore->hasConversationBeenUsed($this->name);
+    }
+
+    /**
+     * @param array $conditions
+     * @return Set
+     */
+    private function createConditions(array $conditions): Set
+    {
+        $conditionObjects = new Set();
+
+        foreach ($conditions as $key => $condition) {
+            try {
+                $conditionObject = $this->createCondition($condition['condition']);
+                $conditionObjects->add($conditionObject);
+            } catch (Exception $e) {
+                Log::debug(
+                    sprintf(
+                        'Could not create condition because: %s',
+                        $e->getMessage()
+                    )
+                );
+            }
+        }
+        return $conditionObjects;
     }
 }

--- a/src/ConversationBuilder/tests/ConversationBuilderTest.php
+++ b/src/ConversationBuilder/tests/ConversationBuilderTest.php
@@ -459,4 +459,20 @@ class ConversationBuilderTest extends TestCase
 
         $this->assertCount(3, $conversationModel->opening_intents);
     }
+
+    public function testConversationWithSceneConditions()
+    {
+        $this->activateConversation($this->conversationWithSceneConditions());
+
+        /** @var Conversation $conversationModel */
+        $conversationModel = Conversation::where('name', 'with_scene_conditions')->first();
+
+        $conversation = $conversationModel->buildConversation();
+
+        $this->assertFalse($conversation->getOpeningScenes()->first()->value->hasConditions());
+        $this->assertTrue($conversation->getScene('scene1')->hasConditions());
+        $this->assertTrue($conversation->getScene('scene2')->hasConditions());
+        $this->assertCount(1, $conversation->getScene('scene1')->getConditions());
+        $this->assertCount(1, $conversation->getScene('scene2')->getConditions());
+    }
 }

--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -557,12 +557,10 @@ class ConversationEngine implements ConversationEngineInterface
     private function filterByConditions(Map $intents): Map
     {
         $filteredIntents = $intents->filter(function ($key, Intent $item) {
-            if ($item->hasConditions()) {
-                /** @var Condition $condition */
-                foreach ($item->getConditions() as $condition) {
-                    if (!$this->operationService->checkCondition($condition)) {
-                        return false;
-                    }
+            /** @var Condition $condition */
+            foreach ($item->getAllConditions() as $condition) {
+                if (!$this->operationService->checkCondition($condition)) {
+                    return false;
                 }
             }
 

--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -214,7 +214,8 @@ class ConversationEngine implements ConversationEngineInterface
         $defaultIntent = $this->interpreterService->getDefaultInterpreter()->interpret($utterance)[0];
         Log::debug(sprintf('Default intent is %s', $defaultIntent->getId()));
 
-        $matchingIntents = $this->getMatchingIntents($utterance, $possibleNextIntents, $defaultIntent);
+        $filteredIntents = $this->filterByConditions($possibleNextIntents);
+        $matchingIntents = $this->getMatchingIntents($utterance, $filteredIntents, $defaultIntent);
 
         if (count($matchingIntents) >= 1) {
             Log::debug(sprintf('There are %s matching intents', count($matchingIntents)));

--- a/src/ConversationEngine/ConversationStore/DGraphConversationQueryFactory.php
+++ b/src/ConversationEngine/ConversationStore/DGraphConversationQueryFactory.php
@@ -193,6 +193,7 @@ class DGraphConversationQueryFactory implements ConversationQueryFactoryInterfac
             Model::UID,
             Model::ID,
             Model::HAS_USER_PARTICIPANT => self::getParticipantGraph(),
+            Model::HAS_CONDITION => self::getConditionGraph(),
             Model::HAS_BOT_PARTICIPANT => self::getParticipantGraph()
         ];
     }

--- a/src/ConversationEngine/ConversationStore/DGraphConversationQueryFactory.php
+++ b/src/ConversationEngine/ConversationStore/DGraphConversationQueryFactory.php
@@ -234,9 +234,11 @@ class DGraphConversationQueryFactory implements ConversationQueryFactoryInterfac
                 Model::ID,
                 Model::USER_PARTICIPATES_IN => [
                     Model::ID,
+                    Model::HAS_CONDITION => self::getConditionGraph()
                 ],
                 Model::BOT_PARTICIPATES_IN => [
                     Model::ID,
+                    Model::HAS_CONDITION => self::getConditionGraph()
                 ]
             ]
         ];

--- a/src/ConversationEngine/ConversationStore/EIModelToGraphConverter.php
+++ b/src/ConversationEngine/ConversationStore/EIModelToGraphConverter.php
@@ -167,6 +167,25 @@ class EIModelToGraphConverter
     }
 
     /**
+     * @param $sceneId
+     * @param Set $conditions
+     * @param ConversationManager $cm
+     * @param bool $clone
+     */
+    public function createSceneConditions($sceneId, Set $conditions, ConversationManager $cm, bool $clone = false): void
+    {
+        /* @var EIModelCondition $conditionData */
+        foreach ($conditions as $conditionData) {
+            /* @var Condition $condition */
+            $condition = $this->convertCondition($conditionData, $clone);
+
+            if (isset($condition)) {
+                $cm->addConditionToScene($sceneId, $condition);
+            }
+        }
+    }
+
+    /**
      * @param ConversationManager $cm
      * @param EIModelConversation $data
      */
@@ -202,8 +221,14 @@ class EIModelToGraphConverter
     {
         $scene = $cm->getScene($data->getId());
         $clone ? false : $scene->setUid($data->getUid());
-        $clone ? false: $scene->getUser()->setUid($data->getUserUid());
-        $clone ? false: $scene->getBot()->setUid($data->getBotUid());
+        $clone ? false : $scene->getUser()->setUid($data->getUserUid());
+        $clone ? false : $scene->getBot()->setUid($data->getBotUid());
+
+        /* @var Set $conditions */
+        $conditions = $data->getConditions();
+        if (!is_null($conditions) && $conditions->count() > 0) {
+            $this->createSceneConditions($data->getId(), $conditions, $cm, $clone);
+        }
 
         $this->updateParticipant(
             $scene->getId(), $scene->getUser(), $cm, $data->getUserSaysIntents(), $clone

--- a/src/ConversationEngine/ConversationStore/EIModelToGraphConverter.php
+++ b/src/ConversationEngine/ConversationStore/EIModelToGraphConverter.php
@@ -224,10 +224,8 @@ class EIModelToGraphConverter
         $clone ? false : $scene->getUser()->setUid($data->getUserUid());
         $clone ? false : $scene->getBot()->setUid($data->getBotUid());
 
-        /* @var Set $conditions */
-        $conditions = $data->getConditions();
-        if (!is_null($conditions) && $conditions->count() > 0) {
-            $this->createSceneConditions($data->getId(), $conditions, $cm, $clone);
+        if ($data->hasConditions()) {
+            $this->createSceneConditions($data->getId(), $data->getConditions(), $cm, $clone);
         }
 
         $this->updateParticipant(

--- a/src/ConversationEngine/ConversationStore/EIModels/EIModelOpeningIntents.php
+++ b/src/ConversationEngine/ConversationStore/EIModels/EIModelOpeningIntents.php
@@ -7,7 +7,6 @@ namespace OpenDialogAi\ConversationEngine\ConversationStore\EIModels;
 use Countable;
 use Ds\Map;
 use Ds\Set;
-use Exception;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use OpenDialogAi\ConversationEngine\ConversationStore\EIModelCreator;
 use OpenDialogAi\ConversationEngine\ConversationStore\EIModelCreatorException;
@@ -41,12 +40,15 @@ class EIModelOpeningIntents extends EIModelBase implements Countable
      * @param array|array $response
      * @param null $additionalParameter
      * @return EIModel
-     * @throws BindingResolutionException
-     * @throws Exception
+     * @throws EIModelCreatorException
      */
     public static function handle(array $response, $additionalParameter = null): EIModel
     {
-        $eiModelCreator = app()->make(EIModelCreator::class);
+        try {
+            $eiModelCreator = app()->make(EIModelCreator::class);
+        } catch (BindingResolutionException $e) {
+            throw new EIModelCreatorException($e->getMessage());
+        }
 
         $intents = new Map();
         foreach ($response as $conversation) {

--- a/src/ConversationEngine/ConversationStore/EIModels/EIModelOpeningIntents.php
+++ b/src/ConversationEngine/ConversationStore/EIModels/EIModelOpeningIntents.php
@@ -7,7 +7,10 @@ namespace OpenDialogAi\ConversationEngine\ConversationStore\EIModels;
 use Countable;
 use Ds\Map;
 use Ds\Set;
+use Exception;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use OpenDialogAi\ConversationEngine\ConversationStore\EIModelCreator;
+use OpenDialogAi\ConversationEngine\ConversationStore\EIModelCreatorException;
 use OpenDialogAi\Core\Conversation\Model;
 
 class EIModelOpeningIntents extends EIModelBase implements Countable
@@ -38,8 +41,8 @@ class EIModelOpeningIntents extends EIModelBase implements Countable
      * @param array|array $response
      * @param null $additionalParameter
      * @return EIModel
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
-     * @throws \Exception
+     * @throws BindingResolutionException
+     * @throws Exception
      */
     public static function handle(array $response, $additionalParameter = null): EIModel
     {
@@ -47,18 +50,7 @@ class EIModelOpeningIntents extends EIModelBase implements Countable
 
         $intents = new Map();
         foreach ($response as $conversation) {
-            $conversationConditions = new Set();
-
-            if (isset($conversation[Model::HAS_CONDITION])) {
-                foreach ($conversation[Model::HAS_CONDITION] as $conditionData) {
-                    /* @var EIModelCondition $condition */
-                    $condition = $eiModelCreator->createEIModel(EIModelCondition::class, $conditionData);
-
-                    if (isset($condition)) {
-                        $conversationConditions->add($condition);
-                    }
-                }
-            }
+            $conversationConditions = self::createConditions($conversation, $eiModelCreator);
 
             if (isset($conversation[Model::HAS_OPENING_SCENE])) {
                 if (isset($conversation[Model::HAS_OPENING_SCENE][0][Model::HAS_USER_PARTICIPANT])) {
@@ -71,6 +63,7 @@ class EIModelOpeningIntents extends EIModelBase implements Countable
                         $openingIntent = $eiModelCreator->createEIModel(EIModelIntent::class, $conversation, $intent);
 
                         $allConditions = $conversationConditions;
+                        self::collectSceneIntents($openingIntent, $intent, $eiModelCreator);
                         $allConditions = $allConditions->merge($openingIntent->getConditions());
                         $openingIntent->setConditions($allConditions);
 
@@ -145,6 +138,57 @@ class EIModelOpeningIntents extends EIModelBase implements Countable
         }
 
         return $intents;
+    }
+
+    /**
+     * @param EIModelIntent $openingIntent
+     * @param array $intent
+     * @param EIModelCreator $eiModelCreator
+     * @throws EIModelCreatorException
+     */
+    private static function collectSceneIntents(EIModelIntent $openingIntent, array $intent, EIModelCreator $eiModelCreator): void
+    {
+        if (key_exists(Model::LISTENED_BY_FROM_SCENES, $intent)) {
+            $participant = $intent[Model::LISTENED_BY_FROM_SCENES][0];
+
+            if (key_exists(Model::BOT_PARTICIPATES_IN, $participant)) {
+                $scene = $participant[Model::BOT_PARTICIPATES_IN][0];
+            } else if (key_exists(Model::USER_PARTICIPATES_IN, $participant)) {
+                $scene = $participant[Model::USER_PARTICIPATES_IN][0];
+            } else {
+                return;
+            }
+
+            $conditions = self::createConditions($scene, $eiModelCreator);
+
+            foreach ($conditions as $condition) {
+                $openingIntent->addCondition($condition);
+            }
+        }
+    }
+
+    /**
+     * @param array $itemWithConditions
+     * @param EIModelCreator $eiModelCreator
+     * @return Set
+     * @throws EIModelCreatorException
+     */
+    private static function createConditions(array $itemWithConditions, EIModelCreator $eiModelCreator): Set
+    {
+        $conditions = new Set();
+
+        if (isset($itemWithConditions[Model::HAS_CONDITION])) {
+            foreach ($itemWithConditions[Model::HAS_CONDITION] as $conditionData) {
+                /* @var EIModelCondition $condition */
+                $condition = $eiModelCreator->createEIModel(EIModelCondition::class, $conditionData);
+
+                if (isset($condition)) {
+                    $conditions->add($condition);
+                }
+            }
+        }
+
+        return $conditions;
     }
 
     /**

--- a/src/ConversationEngine/ConversationStore/EIModels/EIModelScene.php
+++ b/src/ConversationEngine/ConversationStore/EIModels/EIModelScene.php
@@ -38,7 +38,7 @@ class EIModelScene extends EIModelWithConditions
     public static function validate(array $response, $additionalParameter = null): bool
     {
         if (key_exists(Model::ID, $response)) {
-            return key_exists(Model::UID, $response);
+            return parent::validate($response, $additionalParameter) && key_exists(Model::UID, $response);
         } else {
             Log::error('Trying to create scene with no id', $response);
             return false;
@@ -57,7 +57,8 @@ class EIModelScene extends EIModelWithConditions
     {
         $eiModelCreator = app()->make(EIModelCreator::class);
 
-        $scene = new self();
+        /** @var EIModelScene $scene */
+        $scene = parent::handle($response, $additionalParameter);
         $scene->setId($response[Model::ID]);
         $scene->setUid($response[Model::UID]);
 

--- a/src/ConversationEngine/ConversationStore/EIModels/EIModelScene.php
+++ b/src/ConversationEngine/ConversationStore/EIModels/EIModelScene.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Log;
 use OpenDialogAi\ConversationEngine\ConversationStore\EIModelCreator;
 use OpenDialogAi\Core\Conversation\Model;
 
-class EIModelScene extends EIModelBase
+class EIModelScene extends EIModelWithConditions
 {
     private $id;
     private $uid;

--- a/src/ConversationEngine/ConversationStore/EIModels/EIModelWithConditions.php
+++ b/src/ConversationEngine/ConversationStore/EIModels/EIModelWithConditions.php
@@ -39,20 +39,21 @@ class EIModelWithConditions extends EIModelBase
     {
         $eiModelCreator = app()->make(EIModelCreator::class);
 
-        $conversation = new static();
-        $conversation->conditions = new Set();
+        $eiModel = new static();
+        $eiModel->conditions = new Set();
 
         if (isset($response[Model::HAS_CONDITION])) {
             foreach ($response[Model::HAS_CONDITION] as $c) {
+                /** @var EIModelCondition $condition */
                 $condition = $eiModelCreator->createEIModel(EIModelCondition::class, $c);
 
                 if (isset($condition)) {
-                    $conversation->conditions->add($condition);
+                    $eiModel->addCondition($condition);
                 }
             }
         }
 
-        return $conversation;
+        return $eiModel;
     }
 
     /**
@@ -68,7 +69,7 @@ class EIModelWithConditions extends EIModelBase
      */
     public function hasConditions(): bool
     {
-        return !$this->conditions->isEmpty();
+        return !is_null($this->conditions) && !$this->conditions->isEmpty();
     }
 
     /**
@@ -78,5 +79,13 @@ class EIModelWithConditions extends EIModelBase
     public function setConditions(Set $conditions): void
     {
         $this->conditions = $conditions;
+    }
+
+    /**
+     * @param EIModelCondition $condition
+     */
+    public function addCondition(EIModelCondition $condition): void
+    {
+        $this->conditions->add($condition);
     }
 }

--- a/src/Graph/DGraph/DGraphClient.php
+++ b/src/Graph/DGraph/DGraphClient.php
@@ -400,6 +400,7 @@ class DGraphClient
                 ei_type: string
                 id: string
                 has_bot_participant: [uid]
+                has_condition: [uid]
                 has_user_participant: [uid]
             }
             type " . self::CONVERSATION . " {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -377,4 +377,51 @@ EOT;
     {
         $this->setConfigValue('opendialog.context_engine.custom_attributes', $customAttribute);
     }
+
+    protected function conversationWithSceneConditions()
+    {
+        return <<< EOT
+conversation:
+  id: with_scene_conditions
+  scenes:
+    opening_scene:
+      intents:
+        - u:
+            i: opening_user_s1
+            interpreter: interpreter.core.callbackInterpreter
+            scene: scene1
+        - u:
+            i: opening_user_s2
+            interpreter: interpreter.core.callbackInterpreter
+            scene: scene2
+        - u:
+            i: opening_user_none
+            interpreter: interpreter.core.callbackInterpreter
+        - b: 
+            i: opening_bot_complete
+            completes: true
+    scene1:
+      conditions:
+        - condition:
+            operation: is_not_set
+            attributes:
+              attribute1: user.user_email
+      intents:
+        - b: 
+            i: scene1_bot
+            completes: true
+    scene2:
+      conditions:
+        - condition:
+            operation: eq
+            attributes:
+              attribute1: user.user_name
+            parameters:
+              value: test_user
+      intents:
+        - b: 
+            i: scene2_bot
+            completes: true
+EOT;
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -398,6 +398,15 @@ conversation:
             i: opening_user_none
             interpreter: interpreter.core.callbackInterpreter
         - b: 
+            i: opening_bot_response
+        - u:
+            i: opening_user_s3
+            interpreter: interpreter.core.callbackInterpreter
+            scene: scene3
+        - u:
+            i: opening_user_none2
+            interpreter: interpreter.core.callbackInterpreter
+        - b: 
             i: opening_bot_complete
             completes: true
     scene1:
@@ -421,6 +430,18 @@ conversation:
       intents:
         - b: 
             i: scene2_bot
+            completes: true
+    scene3:
+      conditions:
+        - condition:
+            operation: eq
+            attributes:
+              attribute1: user.user_name
+            parameters:
+              value: test_user2
+      intents:
+        - b: 
+            i: scene3_bot
             completes: true
 EOT;
     }


### PR DESCRIPTION
This PR adds the ability to specify scene conditions. It is dependent on #235.

## Changes
### Scene conditions
Conditions can be added to scenes in the following way:

```yaml
conversation:
  id: with_scene_conditions
  scenes:
    opening_scene:
      intents:
        - u:
            i: opening_user_s1
            scene: scene1
        - u:
            i: opening_user_none
        - b: 
            i: opening_bot_response
            completes: true
    scene1:
      conditions:
        - condition:
            operation: is_not_set
            attributes:
              attribute1: user.user_email
      intents:
        - b: 
            i: scene1_bot_response
            completes: true
```

#### Functionality
In terms of functionality, the scene conditions will be pulled from scenes onto the respective cross-scene intents ("said across scenes"). This happens in two places, for opening intents in `EIModelOpeningIntents.collectSceneIntents` and for regular intents in `Intent.getConditionsFromDestinationScene`. In both cases the graph is followed from the cross-scene intent to the participant that listens for it and then up to the scene that the participant is within. From here the conditions are retrieved and added alongside the intent (& potential conversation conditions) for checking.

Previously this PR attempted to use the `ConversationManager` to achieve this. The scene conditions were retrieved and added when calling `userSaysToBotAcrossScenes` or `botSaysToUserAcrossScenes`. While this worked, it meant that the scene conditions were persisted against the intents in the graph, and would be re-added each time, causing consistency issues (as well as memory issues).

#### Behaviour
In the example conversation given above, if the bot receives a 'opening_user_s1' intent, it will have access to the scene1's conditions and these will be checked. If the conditions pass the conversation will progress to scene1, if they fails it will result in a 'NoMatchResponse'. In the future, if we were to allow multiple occurrences of the same intent and we were to have a sequential block of the same intent pointing to various scenes, each destination scenes' conditions would be checked and the conversation would progress to the first scene with passing conditions.