### PR TITLE
Ensuring the status directory is properly cleared

### DIFF
--- a/src/Console/Commands/StoreStatuses.php
+++ b/src/Console/Commands/StoreStatuses.php
@@ -12,7 +12,7 @@ class StoreStatuses extends Command
      *
      * @var string
      */
-    protected $signature = 'statuses:store';
+    protected $signature = 'statuses:store {filename?}';
 
     /**
      * The console command description.
@@ -59,13 +59,24 @@ class StoreStatuses extends Command
             mkdir(storage_path('statuses'));
         }
 
+        $filenameArg = $this->argument('filename');
+
+        if ($filenameArg) {
+            $filename = $filenameArg;
+        } else {
+            $filename = 'statuses_' . date('Y-m-d-H-i-s');
+        }
+
         // Store in CSV file
-        $file = fopen(storage_path('statuses') . '/statuses_' . date('Y-m-d-H-i-s') . '.csv', 'w+');
+        $fullFilePath = storage_path('statuses') . '/' . $filename . '.csv';
+        $file = fopen($fullFilePath, 'w+');
 
         foreach ($data as $row) {
             fputcsv($file, $row);
         }
 
         fclose($file);
+
+        return;
     }
 }

--- a/src/ConversationBuilder/migrations/2019_09_26_104000_alter_status_in_conversations_table.php
+++ b/src/ConversationBuilder/migrations/2019_09_26_104000_alter_status_in_conversations_table.php
@@ -14,7 +14,14 @@ class AlterStatusInConversationsTable extends Migration
      */
     public function up()
     {
-        Artisan::call('statuses:store');
+        try {
+            $numberOfStatuses = count(scandir(storage_path('statuses')));
+        } catch (ErrorException $e) {
+            $numberOfStatuses = 0;
+        }
+
+        $filename = 'statuses_' . $numberOfStatuses . '_' . date('Y-m-d-H-i-s');
+        Artisan::call('statuses:store', [ 'filename' => $filename ]);
 
         if (DB::connection()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME) == 'sqlite') {
             Schema::table('conversations', function (Blueprint $table) {
@@ -28,7 +35,7 @@ class AlterStatusInConversationsTable extends Migration
             DB::statement("ALTER TABLE conversations MODIFY status ENUM('saved', 'activatable', 'activated', 'deactivated', 'archived')");
         }
 
-        Artisan::call('statuses:read');
+        Artisan::call('statuses:read', [ 'filename' => $filename ]);
     }
 
     /**


### PR DESCRIPTION
This PR fixes opendialogai/opendialog#82. The status directory is used to temporarily store conversations statuses during a migration (as the database ENUM must be updated and it there isn't a smooth was to do so). This PR ensures that the status directory doesn't fill up with old CSV files during migrations/test runs.