### PR TITLE
Supporting intents with the same id

### DIFF
--- a/src/ContextEngine/Contexts/User/UserContext.php
+++ b/src/ContextEngine/Contexts/User/UserContext.php
@@ -8,6 +8,7 @@ use OpenDialogAi\ActionEngine\Actions\ActionResult;
 use OpenDialogAi\ContextEngine\ContextManager\AbstractContext;
 use OpenDialogAi\ConversationEngine\ConversationStore\ConversationStoreInterface;
 use OpenDialogAi\ConversationEngine\ConversationStore\EIModelCreatorException;
+use OpenDialogAi\ConversationEngine\ConversationStore\EIModels\EIModelIntent;
 use OpenDialogAi\Core\Attribute\AttributeDoesNotExistException;
 use OpenDialogAi\Core\Attribute\AttributeInterface;
 use OpenDialogAi\Core\Conversation\ChatbotUser;
@@ -185,13 +186,13 @@ class UserContext extends AbstractContext
     /**
      * Gets just the current intent unconnected
      *
-     * @return Intent
+     * @return EIModelIntent
      * @throws EIModelCreatorException
      */
-    public function getCurrentIntent(): Intent
+    public function getCurrentIntent(): EIModelIntent
     {
         $currentIntentId = $this->user->getCurrentIntentUid();
-        return $this->conversationStore->getIntentByUid($currentIntentId);
+        return $this->conversationStore->getEIModelIntentByUid($currentIntentId);
     }
 
     /**

--- a/src/Conversation/ExpectedAttribute.php
+++ b/src/Conversation/ExpectedAttribute.php
@@ -10,6 +10,8 @@ use OpenDialogAi\Core\Graph\Node\Node;
  */
 class ExpectedAttribute extends Node
 {
+    protected static $idIsUnique = false;
+
     public function __construct($id)
     {
         parent::__construct($id);

--- a/src/Conversation/Intent.php
+++ b/src/Conversation/Intent.php
@@ -17,6 +17,8 @@ use OpenDialogAi\Core\Graph\Node\NodeDoesNotExistException;
  */
 class Intent extends Node
 {
+    protected static $idIsUnique = false;
+
     public static $coreAttributes = [
         Model::EI_TYPE,
         Model::COMPLETES,

--- a/src/Conversation/Scene.php
+++ b/src/Conversation/Scene.php
@@ -136,39 +136,32 @@ class Scene extends NodeWithConditions
     /**
      * Get the bot intents said in the scene that have a higher order than the current intent
      * and are in an uninterrupted ascending order.
-     * @param Intent $currentIntent
+     * @param int $currentOrder
      * @return Map
      */
-    public function getNextPossibleBotIntents(Intent $currentIntent): Map
+    public function getNextPossibleBotIntents(int $currentOrder): Map
     {
-        return $this->filterNextPossibleIntents($currentIntent, $this->getIntentsSaidByBotInOrder());
+        return $this->filterNextPossibleIntents($currentOrder, $this->getIntentsSaidByBotInOrder());
     }
 
     /**
      * Get the user intents said in the scene that have a higher order than the current intent
      * and are in an uninterrupted ascending order.
-     * @param Intent $currentIntent
+     * @param int $currentOrder
      * @return Map
      */
-    public function getNextPossibleUserIntents(Intent $currentIntent): Map
+    public function getNextPossibleUserIntents(int $currentOrder): Map
     {
-        return $this->filterNextPossibleIntents($currentIntent, $this->getIntentsSaidByUserInOrder());
+        return $this->filterNextPossibleIntents($currentOrder, $this->getIntentsSaidByUserInOrder());
     }
 
     /**
-     * @param Intent $currentIntent
+     * @param int $currentOrder
      * @param Map $nextPossibleIntents
      * @return Map
      */
-    public function filterNextPossibleIntents(Intent $currentIntent, Map $nextPossibleIntents): Map
+    public function filterNextPossibleIntents(int $currentOrder, Map $nextPossibleIntents): Map
     {
-        // If the current intent is said across scenes, we use 0 - otherwise we use it's order in its scene.
-        if ($currentIntent->hasIncomingEdgeWithRelationship(Model::LISTENS_FOR_ACROSS_SCENES)) {
-            $currentOrder = 0;
-        } else {
-            $currentOrder = $currentIntent->getOrder();
-        }
-
         /** @var Intent $previousKeptIntent */
         $previousKeptIntent = null;
 

--- a/src/ConversationBuilder/Conversation.php
+++ b/src/ConversationBuilder/Conversation.php
@@ -227,7 +227,6 @@ class Conversation extends Model
 
         $dGraph = app()->make(DGraphClient::class);
         $conversationNode = $cm->getConversation();
-        $hash = $conversationNode->hashOrId();
 
         $mutation = new DGraphMutation($conversationNode);
 
@@ -238,7 +237,7 @@ class Conversation extends Model
 
             // Set conversation status to "activated".
             $this->status = ConversationNode::ACTIVATED;
-            $this->graph_uid = $mutationResponse->getData()['uids'][$hash];
+            $this->graph_uid = $mutationResponse->getData()['uids'][$this->name];
             $this->version_number++;
 
             $this->save(['validate' => false]);

--- a/src/ConversationBuilder/Conversation.php
+++ b/src/ConversationBuilder/Conversation.php
@@ -4,6 +4,7 @@ namespace OpenDialogAi\ConversationBuilder;
 
 use Closure;
 use Exception;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
@@ -13,6 +14,7 @@ use OpenDialogAi\ConversationBuilder\Jobs\ValidateConversationScenes;
 use OpenDialogAi\ConversationBuilder\Jobs\ValidateConversationYaml;
 use OpenDialogAi\ConversationBuilder\Jobs\ValidateConversationYamlSchema;
 use OpenDialogAi\ConversationEngine\ConversationStore\ConversationStoreInterface;
+use OpenDialogAi\ConversationEngine\ConversationStore\EIModelCreatorException;
 use OpenDialogAi\Core\Conversation\Action;
 use OpenDialogAi\Core\Conversation\Condition;
 use OpenDialogAi\Core\Conversation\Conversation as ConversationNode;
@@ -139,7 +141,8 @@ class Conversation extends Model
      * Build the conversation's representation.
      *
      * @return ConversationNode
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws BindingResolutionException
+     * @throws EIModelCreatorException
      */
     public function buildConversation()
     {
@@ -209,7 +212,7 @@ class Conversation extends Model
      *
      * @param ConversationNode $conversation
      * @return bool
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws BindingResolutionException
      */
     public function activateConversation(ConversationNode $conversation): bool
     {
@@ -267,7 +270,7 @@ class Conversation extends Model
      * @param $previousUid
      * @param DGraphClient $dGraph
      * @return bool
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws BindingResolutionException
      */
     private function deactivatePrevious($previousUid, DGraphClient $dGraph): bool
     {
@@ -314,7 +317,7 @@ class Conversation extends Model
     /**
      * Deactivate the conversation in DGraph.
      * @return bool
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws BindingResolutionException
      */
     public function deactivateConversation(): bool
     {
@@ -326,7 +329,7 @@ class Conversation extends Model
     /**
      * Archiving the conversation
      * @return bool
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws BindingResolutionException
      */
     public function archiveConversation(): bool
     {
@@ -437,7 +440,7 @@ class Conversation extends Model
      * @param Closure $managerMethod
      * @param $newStatus
      * @return bool
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws BindingResolutionException
      */
     private function setStatus(Closure $managerMethod, $newStatus): bool
     {
@@ -582,7 +585,7 @@ class Conversation extends Model
 
     /**
      * @return bool
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws BindingResolutionException
      */
     public function getHasBeenUsedAttribute(): bool
     {

--- a/src/ConversationBuilder/Conversation.php
+++ b/src/ConversationBuilder/Conversation.php
@@ -226,7 +226,10 @@ class Conversation extends Model
         }
 
         $dGraph = app()->make(DGraphClient::class);
-        $mutation = new DGraphMutation($cm->getConversation());
+        $conversationNode = $cm->getConversation();
+        $hash = $conversationNode->hash();
+
+        $mutation = new DGraphMutation($conversationNode);
 
         /* @var DGraphMutationResponse $mutationResponse */
         $mutationResponse = $dGraph->tripleMutation($mutation);
@@ -235,7 +238,7 @@ class Conversation extends Model
 
             // Set conversation status to "activated".
             $this->status = ConversationNode::ACTIVATED;
-            $this->graph_uid = $mutationResponse->getData()['uids'][$this->name];
+            $this->graph_uid = $mutationResponse->getData()['uids'][$hash];
             $this->version_number++;
 
             $this->save(['validate' => false]);

--- a/src/ConversationBuilder/Conversation.php
+++ b/src/ConversationBuilder/Conversation.php
@@ -227,7 +227,7 @@ class Conversation extends Model
 
         $dGraph = app()->make(DGraphClient::class);
         $conversationNode = $cm->getConversation();
-        $hash = $conversationNode->hash();
+        $hash = $conversationNode->hashOrId();
 
         $mutation = new DGraphMutation($conversationNode);
 

--- a/src/ConversationBuilder/tests/ConversationBuilderTest.php
+++ b/src/ConversationBuilder/tests/ConversationBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenDialogAi\Core\Tests\Unit;
 
+use ErrorException;
 use OpenDialogAi\ContextEngine\Facades\AttributeResolver;
 use OpenDialogAi\ConversationBuilder\Conversation;
 use OpenDialogAi\ConversationBuilder\ConversationStateLog;
@@ -152,7 +153,7 @@ class ConversationBuilderTest extends TestCase
         /** @var ConversationStoreInterface $conversationStore */
         $conversationStore = app()->make(ConversationStoreInterface::class);
 
-        $this->expectException(\ErrorException::class);
+        $this->expectException(ErrorException::class);
         var_dump($conversationStore->getLatestEIModelTemplateVersionByName('hello_bot_world'));
     }
 
@@ -447,5 +448,50 @@ class ConversationBuilderTest extends TestCase
         $response = $client->query($query);
         $this->assertCount(0, $response->getData());
         $this->assertTrue(Conversation::where('name', 'hello_bot_world')->get()->isEmpty());
+    }
+
+    public function testConversationWithManyIntentsWithSameId()
+    {
+        $conversation = $this->createConversationWithManyIntentsWithSameId();
+
+        $this->assertCount(2, $conversation->getAllScenes());
+
+        /** @var Scene $openingScene */
+        $openingScene = $conversation->getOpeningScenes()->first()->value;
+
+        /** @var Scene $secondScene */
+        $secondScene = $conversation->getNonOpeningScenes()->first()->value;
+
+        $this->assertCount(5, $openingScene->getIntentsSaidByUser());
+        $this->assertCount(4, $openingScene->getIntentsSaidByBot());
+
+        $this->assertCount(0, $secondScene->getIntentsSaidByUser());
+        $this->assertCount(1, $secondScene->getIntentsSaidByBot());
+
+        $openingSceneUserIntents = $openingScene->getIntentsSaidByUserInOrder();
+        $openingSceneBotIntents = $openingScene->getIntentsSaidByBotInOrder();
+        $secondSceneBotIntents = $secondScene->getIntentsSaidByBotInOrder();
+
+        $openingSceneUserIntentIds = $openingSceneUserIntents->map(function ($key, Intent $intent) {
+            return $intent->getId();
+        });
+        $openingSceneBotIntentIds = $openingSceneBotIntents->map(function ($key, Intent $intent) {
+            return $intent->getId();
+        });
+        $secondSceneBotIntentIds = $secondSceneBotIntents->map(function ($key, Intent $intent) {
+            return $intent->getId();
+        });
+
+        $this->assertEquals('intent.app.play_game', $openingSceneUserIntentIds->skip(0)->value);
+        $this->assertEquals('intent.app.init_game', $openingSceneBotIntentIds->skip(0)->value);
+        $this->assertEquals('intent.app.send_choice', $openingSceneUserIntentIds->skip(1)->value);
+        $this->assertEquals('intent.app.round_2', $openingSceneBotIntentIds->skip(1)->value);
+        $this->assertEquals('intent.app.send_choice', $openingSceneUserIntentIds->skip(2)->value);
+        $this->assertEquals('intent.app.final_round', $openingSceneBotIntentIds->skip(2)->value);
+        $this->assertEquals('intent.app.send_choice', $openingSceneUserIntentIds->skip(3)->value);
+        $this->assertEquals('intent.app.send_choice', $openingSceneUserIntentIds->skip(4)->value);
+        $this->assertEquals('intent.app.you_won', $openingSceneBotIntentIds->skip(3)->value);
+
+        $this->assertEquals('intent.app.you_lost', $secondSceneBotIntentIds->skip(0)->value);
     }
 }

--- a/src/ConversationBuilder/tests/ConversationBuilderTest.php
+++ b/src/ConversationBuilder/tests/ConversationBuilderTest.php
@@ -154,7 +154,7 @@ class ConversationBuilderTest extends TestCase
         $conversationStore = app()->make(ConversationStoreInterface::class);
 
         $this->expectException(ErrorException::class);
-        var_dump($conversationStore->getLatestEIModelTemplateVersionByName('hello_bot_world'));
+        $conversationStore->getLatestEIModelTemplateVersionByName('hello_bot_world');
     }
 
     public function testConversationDeletionWithManyVersions()

--- a/src/ConversationEngine/ConversationStore/ConversationStoreInterface.php
+++ b/src/ConversationEngine/ConversationStore/ConversationStoreInterface.php
@@ -53,6 +53,7 @@ interface ConversationStoreInterface
     /**
      * @param $templateName
      * @return Conversation
+     * @throws EIModelCreatorException
      */
     public function getLatestTemplateVersionByName($templateName): Conversation;
 

--- a/src/ConversationEngine/tests/ConversationEngineTest.php
+++ b/src/ConversationEngine/tests/ConversationEngineTest.php
@@ -228,7 +228,8 @@ class ConversationEngineTest extends TestCase
         $openingScene = $conversation->getScene('opening_scene');
         $this->assertCount(1, $openingScene->getIntentsSaidByUser());
         /* @var Intent $userIntent */
-        $userIntent = $openingScene->getIntentsSaidByUser()->get('hello_bot');
+        $userIntent = $openingScene->getIntentsSaidByUserInOrder()->skip(0)->value;
+        $this->assertEquals('hello_bot', $userIntent->getId());
         $this->assertTrue($userIntent->hasInterpreter());
         $this->assertTrue($userIntent->causesAction());
         $this->assertEquals($userIntent->getAction()->getId(), 'action.core.example');
@@ -236,7 +237,8 @@ class ConversationEngineTest extends TestCase
 
         $this->assertCount(2, $openingScene->getIntentsSaidByBot());
         /* @var Intent $botIntent */
-        $botIntent = $openingScene->getIntentsSaidByBot()->get('hello_user');
+        $botIntent = $openingScene->getIntentsSaidByBotInOrder()->skip(0)->value;
+        $this->assertEquals('hello_user', $botIntent->getId());
         $this->assertFalse($botIntent->hasInterpreter());
         $this->assertTrue($botIntent->causesAction());
         $this->assertEquals('action.core.example', $botIntent->getAction()->getId());
@@ -245,7 +247,8 @@ class ConversationEngineTest extends TestCase
 
         $this->assertCount(1, $secondScene->getIntentsSaidByUser());
         /* @var Intent $userIntent */
-        $userIntent = $secondScene->getIntentsSaidByUser()->get('how_are_you');
+        $userIntent = $secondScene->getIntentsSaidByUserInOrder()->skip(0)->value;
+        $this->assertEquals('how_are_you', $userIntent->getId());
         $this->assertTrue($userIntent->hasInterpreter());
         $this->assertTrue($userIntent->causesAction());
         $this->assertEquals('action.core.example', $userIntent->getAction()->getId());
@@ -253,7 +256,8 @@ class ConversationEngineTest extends TestCase
 
         $this->assertCount(1, $secondScene->getIntentsSaidByBot());
         /* @var Intent $botIntent */
-        $botIntent = $secondScene->getIntentsSaidByBot()->get('doing_dandy');
+        $botIntent = $secondScene->getIntentsSaidByBotInOrder()->skip(0)->value;
+        $this->assertEquals('doing_dandy', $botIntent->getId());
         $this->assertFalse($botIntent->hasInterpreter());
         $this->assertTrue($botIntent->causesAction());
         $this->assertEquals('action.core.example', $botIntent->getAction()->getId());

--- a/src/Graph/DGraph/DGraphMutation.php
+++ b/src/Graph/DGraph/DGraphMutation.php
@@ -75,7 +75,7 @@ class DGraphMutation
         $attributeStatement = [];
         $update = false;
 
-        $id = $node->uidIsSet() ? $node->getUid() : $node->getId();
+        $id = $node->uidIsSet() ? $node->getUid() : $node->hash();
         if ($node->uidIsSet()) {
             $update = true;
         }
@@ -134,12 +134,12 @@ class DGraphMutation
                 $updateTo = false;
 
                 // Determine what IDs to use based on whether the nodes have uids set or not.
-                $fromId = $node->uidIsSet() ? $node->getUid() : $node->getId();
+                $fromId = $node->uidIsSet() ? $node->getUid() : $node->hash();
                 if ($node->uidIsSet()) {
                     $updateFrom = true;
                 }
 
-                $toId = $edge->getToNode()->uidIsSet() ? $edge->getToNode()->getUid() : $edge->getToNode()->getId();
+                $toId = $edge->getToNode()->uidIsSet() ? $edge->getToNode()->getUid() : $edge->getToNode()->hash();
                 if ($edge->getToNode()->uidIsSet()) {
                     $updateTo = true;
                 }

--- a/src/Graph/DGraph/DGraphMutation.php
+++ b/src/Graph/DGraph/DGraphMutation.php
@@ -75,7 +75,7 @@ class DGraphMutation
         $attributeStatement = [];
         $update = false;
 
-        $id = $node->uidIsSet() ? $node->getUid() : $node->hash();
+        $id = $node->uidIsSet() ? $node->getUid() : $node->hashOrId();
         if ($node->uidIsSet()) {
             $update = true;
         }
@@ -134,12 +134,12 @@ class DGraphMutation
                 $updateTo = false;
 
                 // Determine what IDs to use based on whether the nodes have uids set or not.
-                $fromId = $node->uidIsSet() ? $node->getUid() : $node->hash();
+                $fromId = $node->uidIsSet() ? $node->getUid() : $node->hashOrId();
                 if ($node->uidIsSet()) {
                     $updateFrom = true;
                 }
 
-                $toId = $edge->getToNode()->uidIsSet() ? $edge->getToNode()->getUid() : $edge->getToNode()->hash();
+                $toId = $edge->getToNode()->uidIsSet() ? $edge->getToNode()->getUid() : $edge->getToNode()->hashOrId();
                 if ($edge->getToNode()->uidIsSet()) {
                     $updateTo = true;
                 }

--- a/src/Graph/Edge/EdgeSet.php
+++ b/src/Graph/Edge/EdgeSet.php
@@ -62,7 +62,7 @@ class EdgeSet
 
         /* @var DirectedEdge $edge */
         foreach ($this->edges as $edge) {
-            $toNodes->put($edge->getToNode()->getId(), $edge->getToNode());
+            $toNodes->put($edge->getToNode()->hash(), $edge->getToNode());
         }
 
         return $toNodes;

--- a/src/Graph/Edge/EdgeSet.php
+++ b/src/Graph/Edge/EdgeSet.php
@@ -62,7 +62,7 @@ class EdgeSet
 
         /* @var DirectedEdge $edge */
         foreach ($this->edges as $edge) {
-            $toNodes->put($edge->getToNode()->hash(), $edge->getToNode());
+            $toNodes->put($edge->getToNode()->hashOrId(), $edge->getToNode());
         }
 
         return $toNodes;

--- a/src/Graph/Node/Node.php
+++ b/src/Graph/Node/Node.php
@@ -305,8 +305,16 @@ class Node
      * Returns a hash of the object if ID's aren't unique @see Node::$idIsUnique, otherwise returns the ID
      * @return string
      */
+    public function hashOrId(): string
+    {
+        return static::$idIsUnique ? $this->getId() : $this->hash();
+    }
+
+    /**
+     * @return string
+     */
     public function hash(): string
     {
-        return static::$idIsUnique ? $this->getId() : hash('SHA256', serialize($this));
+        return hash('SHA256', serialize($this));
     }
 }

--- a/src/Graph/Node/Node.php
+++ b/src/Graph/Node/Node.php
@@ -19,6 +19,9 @@ class Node
 {
     use GraphItem, HasAttributesTrait;
 
+    /** @var bool $idIsUnique */
+    protected static $idIsUnique = true;
+
     /**
      * @var Map $outgoingEdges - the set of edges leaving this node keyed by the outgoing relationship name.
      * The structure of the map is [key][EdgeSet]. Key represents the relationship name.
@@ -296,5 +299,14 @@ class Node
         }
 
         return $nodes;
+    }
+
+    /**
+     * Returns a hash of the object if ID's aren't unique @see Node::$idIsUnique, otherwise returns the ID
+     * @return string
+     */
+    public function hash(): string
+    {
+        return static::$idIsUnique ? $this->getId() : hash('SHA256', serialize($this));
     }
 }

--- a/src/Graph/Search/DFS.php
+++ b/src/Graph/Search/DFS.php
@@ -12,14 +12,14 @@ class DFS
 {
     public static function walk(Node $startingNode, Map $visited, callable $callback = null)
     {
-        $visited[$startingNode->getId()] = true;
+        $visited[$startingNode->hash()] = true;
 
         if (isset($callback)) {
             call_user_func($callback, $startingNode);
         }
 
         foreach ($startingNode->getAllNodesOnOutgoingEdges() as $key => $node) {
-            if (!$visited->hasKey($node->getId())) {
+            if (!$visited->hasKey($node->hash())) {
                 self::walk($node, $visited, $callback);
             }
         }

--- a/src/Graph/Search/DFS.php
+++ b/src/Graph/Search/DFS.php
@@ -12,14 +12,14 @@ class DFS
 {
     public static function walk(Node $startingNode, Map $visited, callable $callback = null)
     {
-        $visited[$startingNode->hash()] = true;
+        $visited[$startingNode->hashOrId()] = true;
 
         if (isset($callback)) {
             call_user_func($callback, $startingNode);
         }
 
         foreach ($startingNode->getAllNodesOnOutgoingEdges() as $key => $node) {
-            if (!$visited->hasKey($node->hash())) {
+            if (!$visited->hasKey($node->hashOrId())) {
                 self::walk($node, $visited, $callback);
             }
         }

--- a/src/Graph/tests/DGraph/DGraphTest.php
+++ b/src/Graph/tests/DGraph/DGraphTest.php
@@ -143,6 +143,6 @@ class DGraphTest extends TestCase
         $this->assertEquals(1, preg_match_all('/_:user_participant_in_opening_scene <says_across_scenes>/', $mutationString));
 
         // Ensure the correct number of `intent.app.send_choice` intents were defined
-        $this->assertEquals(4, preg_match_all('/<id> \"intent\.app\.send_choice\"/', $mutationString));
+        $this->assertEquals(4, preg_match_all("/<id> \"intent\.app\.send_choice\"/", $mutationString));
     }
 }

--- a/src/Graph/tests/DGraph/DGraphTest.php
+++ b/src/Graph/tests/DGraph/DGraphTest.php
@@ -4,6 +4,7 @@ namespace OpenDialogAi\Core\Graph\Tests\DGraph;
 
 use OpenDialogAi\ContextEngine\Exceptions\AttributeIsNotSupported;
 use OpenDialogAi\ContextEngine\Facades\AttributeResolver;
+use OpenDialogAi\ConversationBuilder\Conversation;
 use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Graph\DGraph\DGraphClient;
 use OpenDialogAi\Core\Graph\DGraph\DGraphMutation;
@@ -121,5 +122,27 @@ class DGraphTest extends TestCase
         /* @var DGraphQueryResponse $response */
         $response = $this->dGraphClient->query($query);
         $this->assertTrue($response->getData()[0]['name'] == 'Mario Rossi');
+    }
+
+    public function testMutationWithManyIntentsWithSameId()
+    {
+        /** @var Conversation $conversationModel */
+        $conversationModel = Conversation::create([
+            'name' => 'rock_paper_scissors',
+            'model' => $this->getMarkupForManyIntentConversation()
+        ]);
+
+        $conversation = $conversationModel->buildConversation();
+
+        $mutation = new DGraphMutation($conversation);
+
+        $mutationString = $mutation->prepareTripleMutation();
+
+        // Ensure the correct number of incoming intent relationships were specified
+        $this->assertEquals(4, preg_match_all('/_:user_participant_in_opening_scene <says>/', $mutationString));
+        $this->assertEquals(1, preg_match_all('/_:user_participant_in_opening_scene <says_across_scenes>/', $mutationString));
+
+        // Ensure the correct number of `intent.app.send_choice` intents were defined
+        $this->assertEquals(4, preg_match_all('/<id> \"intent\.app\.send_choice\"/', $mutationString));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -382,6 +382,20 @@ EOT;
      */
     public function createConversationWithManyIntentsWithSameId(): ConversationNode
     {
+        $conversationMarkup = $this->getMarkupForManyIntentConversation();
+
+        try {
+            return $this->activateConversation($conversationMarkup);
+        } catch (Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMarkupForManyIntentConversation(): string
+    {
         $conversationMarkup =
             /** @lang yaml */
             <<<EOT
@@ -397,19 +411,19 @@ conversation:
         - u:
             i: intent.app.send_choice
             expected_attributes:
-                - id: game.user_choice
+                - id: user.user_choice
         - b:
             i: intent.app.round_2
         - u:
             i: intent.app.send_choice
             expected_attributes:
-                - id: game.user_choice
+                - id: user.user_choice
         - b:
             i: intent.app.final_round
         - u:
             i: intent.app.send_choice
             expected_attributes:
-                - id: game.user_choice
+                - id: user.user_choice
             conditions:
                 - condition:
                     operation: eq
@@ -421,7 +435,7 @@ conversation:
         - u:
             i: intent.app.send_choice
             expected_attributes:
-                - id: game.user_choice
+                - id: user.user_choice
         - b:
             i: intent.app.you_won
             completes: true
@@ -431,11 +445,6 @@ conversation:
             i: intent.app.you_lost
             completes: true
 EOT;
-
-        try {
-            return $this->activateConversation($conversationMarkup);
-        } catch (Exception $e) {
-            $this->fail($e->getMessage());
-        }
+        return $conversationMarkup;
     }
 }

--- a/tests/Unit/Conversation/ScenesTest.php
+++ b/tests/Unit/Conversation/ScenesTest.php
@@ -178,22 +178,19 @@ class ScenesTest extends TestCase
         /** @var Intent $intent3 */
         $intent3 = $openingScene->getIntentsSaidByUserInOrder()->skip(1)->value;
 
-        /** @var Intent $intent4 */
-        $intent4 = $openingScene->getIntentsSaidByUserInOrder()->skip(2)->value;
-
         // Test that to begin with it returns just intent2
-        $possibleIntents = $openingScene->getNextPossibleBotIntents($intent1);
+        $possibleIntents = $openingScene->getNextPossibleBotIntents($intent1->getOrder());
         $this->assertEquals(1, $possibleIntents->count());
         $this->assertEquals($this->intent2->getId(), $possibleIntents->first()->value->getId());
 
         // Test that it returns the correct intents when the current intent is intent3 and that they are in the right order
-        $possibleIntents = $openingScene->getNextPossibleBotIntents($intent3);
+        $possibleIntents = $openingScene->getNextPossibleBotIntents($intent3->getOrder());
         $this->assertEquals(2, $possibleIntents->count());
         $this->assertEquals($this->intent9->getId(), $possibleIntents->first()->value->getId());
         $this->assertEquals($this->intent10->getId(), $possibleIntents->skip(1)->value->getId());
 
         // Test that it returns the correct intents when the current intent is said across scenes and that they are in the right order
-        $possibleIntents = $latestNewsScene->getNextPossibleBotIntents($intent4);
+        $possibleIntents = $latestNewsScene->getNextPossibleBotIntents(0);
         $this->assertEquals(2, $possibleIntents->count());
         $this->assertEquals($this->intent5->getId(), $possibleIntents->first()->value->getId());
         $this->assertEquals($this->intent6->getId(), $possibleIntents->skip(1)->value->getId());

--- a/tests/Unit/Conversation/ScenesTest.php
+++ b/tests/Unit/Conversation/ScenesTest.php
@@ -168,24 +168,34 @@ class ScenesTest extends TestCase
     public function testGetNextPossibleBotIntents()
     {
         $cm = $this->setupConversation();
-        $openingScene = $cm->getScene(self::OPENING_SCENE);
-        $latestNewsScene = $cm->getScene(self::LATEST_NEWS_SCENE);
+        $conversation = $cm->getConversation();
+        $openingScene = $conversation->getScene(self::OPENING_SCENE);
+        $latestNewsScene = $conversation->getScene(self::LATEST_NEWS_SCENE);
+
+        /** @var Intent $intent1 */
+        $intent1 = $openingScene->getIntentsSaidByUserInOrder()->skip(0)->value;
+
+        /** @var Intent $intent3 */
+        $intent3 = $openingScene->getIntentsSaidByUserInOrder()->skip(1)->value;
+
+        /** @var Intent $intent4 */
+        $intent4 = $openingScene->getIntentsSaidByUserInOrder()->skip(2)->value;
 
         // Test that to begin with it returns just intent2
-        $possibleIntents = $openingScene->getNextPossibleBotIntents($this->intent1);
+        $possibleIntents = $openingScene->getNextPossibleBotIntents($intent1);
         $this->assertEquals(1, $possibleIntents->count());
         $this->assertEquals($this->intent2->getId(), $possibleIntents->first()->value->getId());
 
         // Test that it returns the correct intents when the current intent is intent3 and that they are in the right order
-        $possibleIntents = $openingScene->getNextPossibleBotIntents($this->intent3);
+        $possibleIntents = $openingScene->getNextPossibleBotIntents($intent3);
         $this->assertEquals(2, $possibleIntents->count());
         $this->assertEquals($this->intent9->getId(), $possibleIntents->first()->value->getId());
-        $this->assertEquals($this->intent10->getId(), $possibleIntents->get(self::INTENT_BOT_TO_USER_10)->getId());
+        $this->assertEquals($this->intent10->getId(), $possibleIntents->skip(1)->value->getId());
 
         // Test that it returns the correct intents when the current intent is said across scenes and that they are in the right order
-        $possibleIntents = $latestNewsScene->getNextPossibleBotIntents($this->intent4);
+        $possibleIntents = $latestNewsScene->getNextPossibleBotIntents($intent4);
         $this->assertEquals(2, $possibleIntents->count());
         $this->assertEquals($this->intent5->getId(), $possibleIntents->first()->value->getId());
-        $this->assertEquals($this->intent6->getId(), $possibleIntents->get(self::INTENT_BOT_TO_USER_7)->getId());
+        $this->assertEquals($this->intent6->getId(), $possibleIntents->skip(1)->value->getId());
     }
 }

--- a/tests/Utils/UtteranceGenerator.php
+++ b/tests/Utils/UtteranceGenerator.php
@@ -7,6 +7,7 @@ use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\User;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatButtonResponseUtterance;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatChatOpenUtterance;
+use OpenDialogAi\Core\Utterances\Webchat\WebchatFormResponseUtterance;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatTextUtterance;
 
 /**
@@ -39,6 +40,13 @@ class UtteranceGenerator
         return $utterance;
     }
 
+    /**
+     * If no user is passed in, a random user is generated
+     *
+     * @param $text
+     * @param User $user
+     * @return WebchatTextUtterance
+     */
     public static function generateTextUtterance($text = '', $user = null): WebchatTextUtterance
     {
         if ($user === null) {
@@ -57,6 +65,14 @@ class UtteranceGenerator
         return $utterance;
     }
 
+    /**
+     * If no user is passed in, a random user is generated
+     *
+     * @param $callbackId
+     * @param $value
+     * @param User $user
+     * @return WebchatButtonResponseUtterance
+     */
     public static function generateButtonResponseUtterance(
         $callbackId = '',
         $value = '',
@@ -70,6 +86,36 @@ class UtteranceGenerator
         try {
             $utterance->setCallbackId($callbackId);
             $utterance->setValue($value);
+            $utterance->setUser($user);
+            $utterance->setUserId($user->getId());
+        } catch (FieldNotSupported $e) {
+            //
+        }
+
+        return $utterance;
+    }
+
+    /**
+     * If no user is passed in, a random user is generated
+     *
+     * @param $callbackId
+     * @param $formValues
+     * @param User $user
+     * @return WebchatFormResponseUtterance
+     */
+    public static function generateFormResponseUtterance(
+        $callbackId,
+        $formValues,
+        $user = null
+    ): WebchatFormResponseUtterance {
+        if ($user === null) {
+            $user = self::generateUser();
+        }
+
+        $utterance = new WebchatFormResponseUtterance();
+        try {
+            $utterance->setCallbackId($callbackId);
+            $utterance->setFormValues($formValues);
             $utterance->setUser($user);
             $utterance->setUserId($user->getId());
         } catch (FieldNotSupported $e) {


### PR DESCRIPTION
This PR adds support to allow many intents within a conversation to have the same ID.

## The problem
Prior to this PR, we were not able to have an intent appear multiple times within a scene. If a conversation like this was attempted, it would skip ahead to the last occurrence of the intent.

After some searching, there appeared to be three key three issues that were limiting our ability to support this. Each issue revolved around the presumption that an intent's `id` would be a unique identifier - which isn't always the case. The issues are as follows.

1. **DGraphMutation placeholder syntax**. When a DGraph mutation is prepared (`DGraphMutation.prepareTripleMutation`), we can specify placeholder node UIDs which reference nodes that are not yet persisted. These placeholders were named after the `id` of the given `Node` object. In the case of `Intent`'s this meant that only one of the many intents sharing an `id` would be persisted and that it would have more relationships to participants than expected, due to their placeholders all being the same.
2. **EdgeSet**. To allow for many relationships of the same name the in-memory graph has `EdgeSet`'s which store these many edges. As it is a set, an `EdgeSet` object was already capable of storing many edges to intents with the same `id`. However when trying to retrieve the nodes connected by edges we weren't able to. The `EdgeSet.getToNodes` method stored the 'to' nodes of each edge in a `Map` indexed by `id`, which meant that intents with the same `id` were overwritten in the `Map`.
3. **Depth-first search**. The `DFS.walk` method is used to traverse the in-memory graph when creating a DGraph mutation. To keep track of node's that it has already visited, the `walk` method keeps an array indexed by each `Node`'s `id`. This caused the same problem as in point 2 above, in that intent's with the same ID were considered to be the exact same node.

## Changes
### Hash method
As outlined in the problems above, a key issue is that an intent's `id` is not a unique identifier for a node. This PR introduces a `hash` method to the `Node` class which can provide a unique identifier by serialising the object and then hashing it. This hash value can then be used in various places to support multiple intents with the same id.

As detailed below, this does cause some changes to current behaviour and therefore, currently, each `Node` class must 'opt-in' to using the hash through a static attribute called `$idIsUnique`. Therefore currently this attribute is only set as true on `Intent` and `ExpectedAttribute` classes. In all other causes, where `$idIsUnique` defaults to false, the `hash` method only returns the `id`. With this in mind perhaps there is a better name for this method than `hash` as it does not always return a hash value.

https://github.com/opendialogai/core/blob/ae36f66737b4b54ff8f398391bc0e3a10153fd87/src/Graph/Node/Node.php#L308-L311

### Depth-first search
In the `DFS.walk` method, the use of `Node.getId` has now been replaced with `Node.hash` for indexing the `visited` array. This ensures that where `hash` returns a hash value that `Node`'s with the same `id` can all be visited and considered in the mutation.

### DGraphMutation
In `DGraphMutation.relationshipStatement` and `DGraphMutation.attributeStatement`, the use of `Node.getId` has been replaced by `Node.hash`. This allows unique UID placeholders to be created which ensure that `Node`'s with the same `id` can be correctly persisted to the graph.

### EdgeSet
The most noticeable difference caused by this PR is related to `EdgeSet`'s. We use `EdgeSet`'s to store edges which are connected to a `Node` with the same name. For example a `Conversation` node will have many outgoing edges with the `has_scene` relationship and all these edges will be stored in an `EdgeSet`. This PR updates the `EdgeSet.getToNodes` method to create a `Map` indexed by `Node.hash`. As the `hash` method only returns a hash value when opted-in, the behaviour of this method remains the same for most `Node` classes. However for `Intent`'s and `ExpectedAttribute`'s it will no longer be possible to retrieve their objects by indexing the `id`.

The most notable use of `getToNodes` is by `Node.getNodesConnectedByOutgoingRelationship` which returns the `Map` produced by `getToNodes`. When dealing with `Intent`'s and `ExpectedAttribute`'s we will have to essentially treat this `Map` as if it were a `Set`.