### PR TITLE
Support conditions on incoming intents

### DIFF
--- a/src/ConversationEngine/MatchingIntents.php
+++ b/src/ConversationEngine/MatchingIntents.php
@@ -2,7 +2,7 @@
 
 namespace OpenDialogAi\ConversationEngine;
 
-use Ds\Map;
+use Ds\Set;
 use OpenDialogAi\Core\Conversation\Intent;
 
 /**
@@ -10,12 +10,12 @@ use OpenDialogAi\Core\Conversation\Intent;
  */
 class MatchingIntents implements \Countable
 {
-    /** @var Map */
-    private $intentsMap;
+    /** @var Set */
+    private $intentsSet;
 
     public function __construct()
     {
-        $this->intentsMap = new Map();
+        $this->intentsSet = new Set();
     }
 
     /**
@@ -26,7 +26,7 @@ class MatchingIntents implements \Countable
      */
     public function addMatchingIntent(Intent $intent): MatchingIntents
     {
-        $this->intentsMap->put($intent->getId(), $intent);
+        $this->intentsSet->add($intent);
         return $this;
     }
 
@@ -38,7 +38,7 @@ class MatchingIntents implements \Countable
      */
     public function getBestMatch(): Intent
     {
-        return $this->intentsMap->first()->value;
+        return $this->intentsSet->first();
     }
 
     /**
@@ -52,6 +52,6 @@ class MatchingIntents implements \Countable
      */
     public function count()
     {
-        return $this->intentsMap->count();
+        return $this->intentsSet->count();
     }
 }

--- a/tests/Feature/NextIntentDetectionTest.php
+++ b/tests/Feature/NextIntentDetectionTest.php
@@ -290,7 +290,9 @@ EOT;
         $this->assertEquals('intent.app.final_round', $conversationContext->getAttributeValue('next_intent'));
 
         // Simulate a bot win
-        ContextService::getUserContext()->addAttribute(AttributeResolver::getAttributeFor('game_result', 'BOT_WINS'));
+        $utterance->getUser()->setCustomParameters([
+            'game_result' => 'BOT_WINS'
+        ]);
 
         $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('intent.app.send_choice', $utterance->getUser()));
         $this->assertEquals('intent.app.send_choice', $conversationContext->getAttributeValue('interpreted_intent'));

--- a/tests/Feature/NextIntentDetectionTest.php
+++ b/tests/Feature/NextIntentDetectionTest.php
@@ -13,14 +13,12 @@ class NextIntentDetectionTest extends TestCase
 {
     public function setUp(): void
     {
-        $this->setupWithDGraphInit = false;
         parent::setUp();
 
-        AttributeResolver::registerAttributes([
-            'user_name' => StringAttribute::class
+        $this->setCustomAttributes([
+            'user_choice' => StringAttribute::class,
+            'game_result' => StringAttribute::class
         ]);
-
-        $this->initDDgraph();
 
         $this->activateConversation($this->conversation4());
     }
@@ -42,24 +40,24 @@ class NextIntentDetectionTest extends TestCase
         // Start the conversation
         $utterance = UtteranceGenerator::generateChatOpenUtterance('hello_bot');
         $openDialogController->runConversation($utterance);
-        $this->assertEquals('test_conversation', $conversationContext->getAttributeValue('current_conversation'));
-        $this->assertEquals('hello_bot', $conversationContext->getAttributeValue('interpreted_intent'));
-        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
-        $this->assertEquals('hello_user', $conversationContext->getAttributeValue('next_intent'));
+        $this->assertEquals($conversationContext->getAttributeValue('current_conversation'), 'test_conversation');
+        $this->assertEquals($conversationContext->getAttributeValue('interpreted_intent'), 'hello_bot');
+        $this->assertEquals($conversationContext->getAttributeValue('current_scene'), 'opening_scene');
+        $this->assertEquals($conversationContext->getAttributeValue('next_intent'), 'hello_user');
 
         // Ask about the weather - this should keep the user in the opening scene
         $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('ask_weather', $utterance->getUser()));
-        $this->assertEquals('ask_weather', $conversationContext->getAttributeValue('interpreted_intent'));
-        $this->assertEquals('test_conversation', $conversationContext->getAttributeValue('current_conversation'));
-        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
-        $this->assertEquals('send_weather', $conversationContext->getAttributeValue('next_intent'));
+        $this->assertEquals($conversationContext->getAttributeValue('interpreted_intent'), 'ask_weather');
+        $this->assertEquals($conversationContext->getAttributeValue('current_conversation'), 'test_conversation');
+        $this->assertEquals($conversationContext->getAttributeValue('current_scene'), 'opening_scene');
+        $this->assertEquals($conversationContext->getAttributeValue('next_intent'), 'send_weather');
 
         // Respond to the weather
         $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('respond_weather', $utterance->getUser()));
-        $this->assertEquals('respond_weather', $conversationContext->getAttributeValue('interpreted_intent'));
-        $this->assertEquals('test_conversation', $conversationContext->getAttributeValue('current_conversation'));
-        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
-        $this->assertEquals('finish', $conversationContext->getAttributeValue('next_intent'));
+        $this->assertEquals($conversationContext->getAttributeValue('interpreted_intent'), 'respond_weather');
+        $this->assertEquals($conversationContext->getAttributeValue('current_conversation'), 'test_conversation');
+        $this->assertEquals($conversationContext->getAttributeValue('current_scene'), 'opening_scene');
+        $this->assertEquals($conversationContext->getAttributeValue('next_intent'), 'finish');
     }
 
     public function testSaidAcrossScene()
@@ -80,76 +78,21 @@ class NextIntentDetectionTest extends TestCase
         $utterance = UtteranceGenerator::generateChatOpenUtterance('hello_bot');
         $openDialogController->runConversation($utterance);
         $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('ask_chat', $utterance->getUser()));
-        $this->assertEquals('ask_chat', $conversationContext->getAttributeValue('interpreted_intent'));
-        $this->assertEquals('test_conversation', $conversationContext->getAttributeValue('current_conversation'));
-        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
-        $this->assertEquals('start_chat', $conversationContext->getAttributeValue('next_intent'));
+        $this->assertEquals($conversationContext->getAttributeValue('interpreted_intent'), 'ask_chat');
+        $this->assertEquals($conversationContext->getAttributeValue('current_conversation'), 'test_conversation');
+        $this->assertEquals($conversationContext->getAttributeValue('current_scene'), 'opening_scene');
+        $this->assertEquals($conversationContext->getAttributeValue('next_intent'), 'start_chat');
 
         // Respond to the weather
         $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('how_are_you', $utterance->getUser()));
-        $this->assertEquals('how_are_you', $conversationContext->getAttributeValue('interpreted_intent'));
-        $this->assertEquals('test_conversation', $conversationContext->getAttributeValue('current_conversation'));
-        $this->assertEquals('scene2', $conversationContext->getAttributeValue('current_scene'));
-        $this->assertEquals('doing_dandy', $conversationContext->getAttributeValue('next_intent'));
+        $this->assertEquals($conversationContext->getAttributeValue('interpreted_intent'), 'how_are_you');
+        $this->assertEquals($conversationContext->getAttributeValue('current_conversation'), 'test_conversation');
+        $this->assertEquals($conversationContext->getAttributeValue('current_scene'), 'scene2');
+        $this->assertEquals($conversationContext->getAttributeValue('next_intent'), 'doing_dandy');
     }
 
-    public function testConditionsOnOutgoingIntents()
+    public function testConversationWithManyIntentsWithSameIdAndIncomingConditions()
     {
-        $this->setSupportedCallbacks([
-            'hello_bot' => 'hello_bot'
-        ]);
-
-        $openDialogController = resolve(OpenDialogController::class);
-
-        $this->activateConversation($this->testConversationWithOutgoingIntentConditions());
-
-        $conversationContext = ContextService::getConversationContext();
-
-        // Expect to get to 'response_without_name' because the user name isn't set
-        $utterance = UtteranceGenerator::generateChatOpenUtterance('hello_bot');
-        $openDialogController->runConversation($utterance);
-        $this->assertEquals('hello_bot', $conversationContext->getAttributeValue('interpreted_intent'));
-        $this->assertEquals('with_outgoing_intent_conditions', $conversationContext->getAttributeValue('current_conversation'));
-        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
-        $this->assertEquals('response_without_name', $conversationContext->getAttributeValue('next_intent'));
-
-        // Expect to get to 'answer_without_name' because the user name isn't set
-        $utterance = UtteranceGenerator::generateChatOpenUtterance('question', $utterance->getUser());
-        $openDialogController->runConversation($utterance);
-        $this->assertEquals('question', $conversationContext->getAttributeValue('interpreted_intent'));
-        $this->assertEquals('with_outgoing_intent_conditions', $conversationContext->getAttributeValue('current_conversation'));
-        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
-        $this->assertEquals('answer_without_name', $conversationContext->getAttributeValue('next_intent'));
-
-        // New user
-        $utterance = UtteranceGenerator::generateChatOpenUtterance('hello_bot');
-        $utterance->getUser()->setCustomParameters([
-            "user_name" => "test"
-        ]);
-
-        // Expect to get to 'response_with_name' because the user name is set
-        $openDialogController->runConversation($utterance);
-        $this->assertEquals('hello_bot', $conversationContext->getAttributeValue('interpreted_intent'));
-        $this->assertEquals('with_outgoing_intent_conditions', $conversationContext->getAttributeValue('current_conversation'));
-        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
-        $this->assertEquals('response_with_name', $conversationContext->getAttributeValue('next_intent'));
-
-        // Expect to get to 'answer_with_name' because the user name is set
-        $utterance = UtteranceGenerator::generateChatOpenUtterance('question', $utterance->getUser());
-        $openDialogController->runConversation($utterance);
-        $this->assertEquals('question', $conversationContext->getAttributeValue('interpreted_intent'));
-        $this->assertEquals('with_outgoing_intent_conditions', $conversationContext->getAttributeValue('current_conversation'));
-        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
-        $this->assertEquals('answer_with_name', $conversationContext->getAttributeValue('next_intent'));
-    }
-
-    public function testConversationWithManyIntentsWithSameId()
-    {
-        $this->setCustomAttributes([
-            'user_choice' => StringAttribute::class,
-            'game_result' => StringAttribute::class
-        ]);
-
         $openDialogController = resolve(OpenDialogController::class);
 
         $this->createConversationWithManyIntentsWithSameId();
@@ -174,6 +117,15 @@ class NextIntentDetectionTest extends TestCase
         $this->assertEquals('rock_paper_scissors', $conversationContext->getAttributeValue('current_conversation'));
         $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
         $this->assertEquals('intent.app.final_round', $conversationContext->getAttributeValue('next_intent'));
+
+        // Simulate a bot win
+        ContextService::getUserContext()->addAttribute(AttributeResolver::getAttributeFor('game_result', 'BOT_WINS'));
+
+        $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('intent.app.send_choice', $utterance->getUser()));
+        $this->assertEquals('intent.app.send_choice', $conversationContext->getAttributeValue('interpreted_intent'));
+        $this->assertEquals('rock_paper_scissors', $conversationContext->getAttributeValue('current_conversation'));
+        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
+        $this->assertEquals('intent.app.you_lost', $conversationContext->getAttributeValue('next_intent'));
     }
 
     public function getTestConversation()
@@ -212,51 +164,5 @@ conversation:
             i: doing_dandy
             completes: true
 EOT;
-    }
-
-    public function testConversationWithOutgoingIntentConditions()
-    {
-        return <<<EOT
-conversation:
-  id: with_outgoing_intent_conditions
-  scenes:
-    opening_scene:
-      intents:
-        - u: 
-            i: hello_bot
-        - b: 
-            i: response_with_name
-            conditions:
-                - condition:
-                    operation: is_set
-                    attributes:
-                        attribute1: user.user_name
-        - b:
-            i: response_without_name
-            conditions:
-                - condition:
-                    operation: is_not_set
-                    attributes:
-                        attribute1: user.user_name
-        - u: 
-            i: question
-        - b: 
-            i: answer_with_name
-            conditions:
-                - condition:
-                    operation: is_set
-                    attributes:
-                        attribute1: user.user_name
-            completes: true
-        - b:
-            i: answer_without_name
-            conditions:
-                - condition:
-                    operation: is_not_set
-                    attributes:
-                        attribute1: user.user_name
-            completes: true
-EOT;
-
     }
 }


### PR DESCRIPTION
This PR allows conversation designers to add conditions to incoming intents. It is dependent on the currently un-merged work in #248, #239 & #235 and is depended on by #256.

## Changes
The bulk of the changes in this PR are additions to test cases, which ensure that incoming intents work as expected in various scenarios (as opening intents, as cross-scene intents and as intents with expected attributes). The changes required to add this support were fairly brief and are as follows.

### MatchingIntents
The `MatchingIntents` class is a small class which is essentially a wrapper around a collection of intents. Previously this was implemented using a `Map` but this has now been updated to use a `Set`.

### ConversationEngine
The key part of adding this support was having `ConversationEngine.getMatchingIntents` call the `ConversationEngine.filterByConditions` method, which filters conditions depending on whether their conditions pass.

As discussed with @stu-greenshoots & @istos, for incoming intents the condition filtering happens after interpretation so that we are able to filter from a collection of matching interpreted intents. Our hope was that an incoming intent could have a condition on an attribute that the interpreter had just output, however this proved beyond the scope of this PR and has been split out into #256 where the issue has been expanded upon.