### PR TITLE
Adds for an intent context for use with incoming intent conditions

### DIFF
--- a/src/Attribute/AbstractAttribute.php
+++ b/src/Attribute/AbstractAttribute.php
@@ -115,4 +115,12 @@ abstract class AbstractAttribute implements AttributeInterface
     {
         $this->id = $id;
     }
+
+    /**
+     * @return AbstractAttribute
+     */
+    public function copy(): AbstractAttribute
+    {
+        return clone $this;
+    }
 }

--- a/src/ContextEngine/ContextEngineServiceProvider.php
+++ b/src/ContextEngine/ContextEngineServiceProvider.php
@@ -6,6 +6,7 @@ use Carbon\Laravel\ServiceProvider;
 use OpenDialogAi\ContextEngine\AttributeResolver\AttributeResolver;
 use OpenDialogAi\ContextEngine\ContextManager\ContextService;
 use OpenDialogAi\ContextEngine\ContextManager\ContextServiceInterface;
+use OpenDialogAi\ContextEngine\Contexts\Intent\IntentContext;
 use OpenDialogAi\ContextEngine\Contexts\User\UserService;
 use OpenDialogAi\ConversationEngine\ConversationStore\ConversationStoreInterface;
 use OpenDialogAi\Core\Graph\DGraph\DGraphClient;
@@ -34,6 +35,8 @@ class ContextEngineServiceProvider extends ServiceProvider
             $contextService->createContext(ContextService::SESSION_CONTEXT);
 
             $contextService->createContext(ContextService::CONVERSATION_CONTEXT);
+
+            $contextService->addContext(new IntentContext());
 
             if (is_array(config('opendialog.context_engine.custom_contexts'))) {
                 $contextService->loadCustomContexts(config('opendialog.context_engine.custom_contexts'));

--- a/src/ContextEngine/ContextManager/ContextService.php
+++ b/src/ContextEngine/ContextManager/ContextService.php
@@ -6,6 +6,7 @@ use Ds\Map;
 use Illuminate\Support\Facades\Log;
 use OpenDialogAi\ContextEngine\ContextParser;
 use OpenDialogAi\ContextEngine\Contexts\Custom\AbstractCustomContext;
+use OpenDialogAi\ContextEngine\Contexts\Intent\IntentContext;
 use OpenDialogAi\ContextEngine\Contexts\User\UserContext;
 use OpenDialogAi\ContextEngine\Contexts\User\UserService;
 use OpenDialogAi\ContextEngine\Exceptions\AttributeIsNotSupported;
@@ -19,7 +20,12 @@ use OpenDialogAi\Core\Utterances\UtteranceInterface;
 
 class ContextService implements ContextServiceInterface
 {
-    public static $coreContexts = [UserContext::USER_CONTEXT, self::SESSION_CONTEXT, self::CONVERSATION_CONTEXT];
+    public static $coreContexts = [
+        UserContext::USER_CONTEXT,
+        IntentContext::INTENT_CONTEXT,
+        self::SESSION_CONTEXT,
+        self::CONVERSATION_CONTEXT
+    ];
 
     /* @var Map $activeContexts - a container for contexts that the service is managing */
     private $activeContexts;

--- a/src/ContextEngine/Contexts/Intent/IntentContext.php
+++ b/src/ContextEngine/Contexts/Intent/IntentContext.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace OpenDialogAi\ContextEngine\Contexts\Intent;
+
+
+use OpenDialogAi\ContextEngine\ContextManager\AbstractContext;
+use OpenDialogAi\Core\Attribute\AttributeInterface;
+
+class IntentContext extends AbstractContext
+{
+    public const INTENT_CONTEXT = '_intent';
+
+    public function __construct()
+    {
+        parent::__construct(self::INTENT_CONTEXT);
+    }
+
+    public function refresh(): void
+    {
+        /** @var AttributeInterface $attribute */
+        foreach ($this->getAttributes() as $attribute) {
+            $this->removeAttribute($attribute->getId());
+        }
+    }
+}

--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Log;
 use OpenDialogAi\ActionEngine\Actions\ActionResult;
 use OpenDialogAi\ActionEngine\Exceptions\ActionNotAvailableException;
 use OpenDialogAi\ActionEngine\Service\ActionEngineInterface;
+use OpenDialogAi\ContextEngine\Contexts\Intent\IntentContext;
 use OpenDialogAi\ContextEngine\Contexts\User\CurrentIntentNotSetException;
 use OpenDialogAi\ContextEngine\Contexts\User\UserContext;
 use OpenDialogAi\ContextEngine\Exceptions\ContextDoesNotExistException;
@@ -518,7 +519,7 @@ class ConversationEngine implements ConversationEngineInterface
             }
         }
 
-        $filteredIntents = $this->filterByConditions($matching);
+        $filteredIntents = $this->filterByConditions($matching, true);
 
         $matchingIntents = new MatchingIntents();
         foreach ($filteredIntents as $matchingIntent) {
@@ -558,16 +559,39 @@ class ConversationEngine implements ConversationEngineInterface
 
     /**
      * @param Map $intents
+     * @param bool $useIntentContext
      * @return Map
      */
-    private function filterByConditions(Map $intents): Map
+    private function filterByConditions(Map $intents, bool $useIntentContext = false): Map
     {
-        $filteredIntents = $intents->filter(function ($key, Intent $item) {
+        if ($useIntentContext) {
+            /** @var IntentContext $intentContext */
+            $intentContext = ContextService::getContext(IntentContext::INTENT_CONTEXT);
+        } else {
+            $intentContext = null;
+        }
+
+        $filteredIntents = $intents->filter(function ($key, Intent $item) use ($intentContext) {
+            if ($intentContext) {
+                /** @var AttributeInterface $attribute */
+                foreach ($item->getNonCoreAttributes() as $attribute) {
+                    $intentContext->addAttribute($attribute->copy());
+                }
+            }
+
             /** @var Condition $condition */
             foreach ($item->getAllConditions() as $condition) {
                 if (!$this->operationService->checkCondition($condition)) {
+                    if ($intentContext) {
+                        $intentContext->refresh();
+                    }
+
                     return false;
                 }
+            }
+
+            if ($intentContext) {
+                $intentContext->refresh();
             }
 
             return true;

--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -579,14 +579,13 @@ class ConversationEngine implements ConversationEngineInterface
                 }
             }
 
+            $result = true;
+
             /** @var Condition $condition */
             foreach ($item->getAllConditions() as $condition) {
                 if (!$this->operationService->checkCondition($condition)) {
-                    if ($intentContext) {
-                        $intentContext->refresh();
-                    }
-
-                    return false;
+                    $result = false;
+                    break;
                 }
             }
 
@@ -594,7 +593,7 @@ class ConversationEngine implements ConversationEngineInterface
                 $intentContext->refresh();
             }
 
-            return true;
+            return $result;
         });
 
         return $filteredIntents;

--- a/tests/Feature/AttributeExtractionTest.php
+++ b/tests/Feature/AttributeExtractionTest.php
@@ -73,10 +73,10 @@ class AttributeExtractionTest extends TestCase
     {
         $utterance = UtteranceGenerator::generateChatOpenUtterance('my_name_is');
 
-        $this->assertCount(2, ContextService::getContexts());
+        $this->assertCount(3, ContextService::getContexts());
         /* @var UserContext $userContext; */
         $userContext = ContextService::createUserContext($utterance);
-        $this->assertCount(3, ContextService::getContexts());
+        $this->assertCount(4, ContextService::getContexts());
 
         $intent = $this->conversationEngine->getNextIntent($userContext, $utterance);
 

--- a/tests/Feature/NextIntentDetectionTest.php
+++ b/tests/Feature/NextIntentDetectionTest.php
@@ -333,20 +333,18 @@ conversation:
             i: intent.app.make_choice
             expected_attributes:
               - id: user.choice
-        - b:
-            i: intent.app.response
-        - u:
-            i: intent.app.continue
             conditions:
                 - condition:
                     operation: eq
                     attributes:
-                        attribute1: user.choice
+                        attribute1: _intent.choice
                     parameters:
                         value: 'left'
             scene: left_path
         - u:
-            i: intent.app.continue
+            i: intent.app.make_choice
+            expected_attributes:
+              - id: user.choice
         - b:
             i: intent.app.right_path_end
             completes: true
@@ -374,15 +372,7 @@ EOT;
 
         $utterance = UtteranceGenerator::generateButtonResponseUtterance('make_choice', 'choice.left', $utterance->getUser());
         $openDialogController->runConversation($utterance);
-        $this->assertEquals('left', ContextService::getUserContext()->getAttributeValue('choice'));
         $this->assertEquals('intent.app.make_choice', $conversationContext->getAttributeValue('interpreted_intent'));
-        $this->assertEquals('my_conversation', $conversationContext->getAttributeValue('current_conversation'));
-        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
-        $this->assertEquals('intent.app.response', $conversationContext->getAttributeValue('next_intent'));
-
-        $utterance = UtteranceGenerator::generateChatOpenUtterance('intent.app.continue', $utterance->getUser());
-        $openDialogController->runConversation($utterance);
-        $this->assertEquals('intent.app.continue', $conversationContext->getAttributeValue('interpreted_intent'));
         $this->assertEquals('my_conversation', $conversationContext->getAttributeValue('current_conversation'));
         $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
         $this->assertEquals('intent.app.left_path_end', $conversationContext->getAttributeValue('next_intent'));


### PR DESCRIPTION
This PR adds a new context that allows a conditions on incoming intents to access interpreted attributes. This PR is dependent on #252 and its dependent PR's.

## Problem
The reason this new context is necessary is because our assumption about incoming intent conditions being "post-conditions" was missing something. The missing insight was that interpreted intents do not add their attributes to contexts until **after** a single intent is matched. We had decided that incoming intent conditions should be able to access such attributes, which is not currently possible.

Allowing each interpreted intent to populate contexts prior to condition checking is not desirable. If we allowed this, we would be allowing potentially incorrect intents to dirty contexts which we would then need a way to clean out after condition checking. Ultimately doing that would surely bring many new problems and consequences.

## Solution
A way to meet our initial expectations and also side-step the issue of dirtying contexts ahead of condition checking is to create a new intent context. This context is populated only during condition checking and is immediately cleared out afterwards. This means that the intent context only ever holds attributes for a single interpreted intent immediately **after** interpretation and **during** condition checking.

This enables us to write conditions such as appears in the following example.

https://github.com/opendialogai/core/blob/ed46213bde9ceb4bd17ed32a678e3d2e0c471dbf/tests/Feature/NextIntentDetectionTest.php#L326-L350

## Changes
### IntentContext
A new core context has been added called `IntentContext`. It only implements a single new method called `refresh` which simply iterates through all its attributes and removes them all. The context does not persist its attributes as they are ephemeral.

### ConversationEngine
Changes have been made to `ConversationEngine.filterByConditions` to make use of the new context. As each interpreted intent is iterated through, the intent context is populated with the attributes extracted by the interpreter and the conditions are checked. This means that a conversation designer is able to specify conditions that use attributes in the `_intent` context. This means that a conversation designer is able to check whether the interpreter's extracted attributes are suitable and direct the conversation according. After condition checking the intent, the context is refreshed and all attributes are removed.