### PR TITLE
Use toString when filling attributes in message templates

### DIFF
--- a/src/ResponseEngine/Service/ResponseEngineService.php
+++ b/src/ResponseEngine/Service/ResponseEngineService.php
@@ -81,8 +81,8 @@ class ResponseEngineService implements ResponseEngineServiceInterface
                 $replacement = ' ';
                 try {
                     [$contextId, $attributeName] = ContextParser::determineContextAndAttributeId($attributeId);
-                    $replacement = ContextService::getAttributeValue($attributeName, $contextId);
-                    $replacement = $this->escapeCharacters($replacement);
+                    $replacement = ContextService::getAttribute($attributeName, $contextId);
+                    $replacement = $this->escapeCharacters($replacement->toString());
                 } catch (ContextDoesNotExistException $e) {
                     Log::warning($e->getMessage());
                 } catch (AttributeDoesNotExistException $e) {


### PR DESCRIPTION
This PR updates the `ResponseEngineService.fillAttributes` method to use each attribute's `toString` method when filling attributes. This ensures that each attribute is in control of how it gets displayed to a user.