### PR TITLE
Update improvements

### DIFF
--- a/src/ContextEngine/Contexts/User/UserService.php
+++ b/src/ContextEngine/Contexts/User/UserService.php
@@ -564,7 +564,13 @@ class UserService
 
                             $user->addUserAttribute($attribute)->setUid($userAttribute[Model::UID]);
                         } catch (AttributeIsNotSupported $e) {
-                            Log::warning(sprintf('Attribute for user could not be resolved %s => %s', $name, $value));
+                            Log::warning(
+                                sprintf(
+                                    'Attribute for user could not be resolved %s => %s',
+                                    $userAttribute[Model::ID],
+                                    $userAttribute[Model::USER_ATTRIBUTE_VALUE]
+                                )
+                            );
                             continue;
                         }
                     }

--- a/src/ConversationBuilder/Conversation.php
+++ b/src/ConversationBuilder/Conversation.php
@@ -626,6 +626,8 @@ class Conversation extends Model
         return $history->filter(function ($item) {
             // Retain if it's the first activity record or if it's a record with the version has incremented
             return isset($item['properties']['old'])
+                && isset($item['properties']['old']['version_number'])
+                && isset($item['properties']['attributes']['version_number'])
                 && $item['properties']['attributes']['version_number'] != $item['properties']['old']['version_number'];
         })->values()->map(function ($item) {
             return [

--- a/src/ConversationBuilder/migrations/2019_09_26_104000_alter_status_in_conversations_table.php
+++ b/src/ConversationBuilder/migrations/2019_09_26_104000_alter_status_in_conversations_table.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use OpenDialogAi\ConversationBuilder\Conversation;
 
 class AlterStatusInConversationsTable extends Migration
 {
@@ -32,6 +33,11 @@ class AlterStatusInConversationsTable extends Migration
                 $table->enum('status', ['saved', 'activatable', 'activated', 'deactivated', 'archived'])->default('');
             });
         } else {
+            Conversation::all()->each(function (Conversation $conversation) {
+                $conversation->status = 'saved';
+                $conversation->save(['validate' => false]);
+            });
+
             DB::statement("ALTER TABLE conversations MODIFY status ENUM('saved', 'activatable', 'activated', 'deactivated', 'archived')");
         }
 


### PR DESCRIPTION
This PR improves the process of updating an OpenDialog application from a pre-#229 version. It makes changes that account for the lack of a "version_number" attribute in a conversation's history and ensures the migration can run successfully.