### PR TITLE
Feature/hash generation performance improvement

### DIFF
--- a/src/Graph/Node/Node.php
+++ b/src/Graph/Node/Node.php
@@ -22,6 +22,8 @@ class Node
     /** @var bool $idIsUnique */
     protected static $idIsUnique = true;
 
+    protected $uniqueId;
+
     /**
      * @var Map $outgoingEdges - the set of edges leaving this node keyed by the outgoing relationship name.
      * The structure of the map is [key][EdgeSet]. Key represents the relationship name.
@@ -315,6 +317,10 @@ class Node
      */
     public function hash(): string
     {
-        return hash('SHA256', serialize($this));
+       if (!isset($this->uniqueId)) {
+           $this->uniqueId = uniqid();
+       }
+
+       return $this->uniqueId;
     }
 }

--- a/src/Graph/Node/Node.php
+++ b/src/Graph/Node/Node.php
@@ -317,10 +317,10 @@ class Node
      */
     public function hash(): string
     {
-       if (!isset($this->uniqueId)) {
-           $this->uniqueId = uniqid();
-       }
+        if (!isset($this->uniqueId)) {
+            $this->uniqueId = uniqid();
+        }
 
-       return $this->uniqueId;
+        return $this->uniqueId;
     }
 }


### PR DESCRIPTION
Based on image below the performance improvement was such that the hash() call consumed less that 1% of the overall effort for the entire call so it didn't even register after the change with blackfire. 

![image](https://user-images.githubusercontent.com/80763/69224723-57cb9a00-0b7d-11ea-8139-2dad26059c7c.png)
