### PR TITLE
Adding support for virtual intents

### DIFF
--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -18,11 +18,13 @@ use OpenDialogAi\ConversationEngine\ConversationStore\ConversationStoreInterface
 use OpenDialogAi\ConversationEngine\ConversationStore\EIModelCreatorException;
 use OpenDialogAi\ConversationEngine\ConversationStore\EIModels\EIModelCondition;
 use OpenDialogAi\ConversationEngine\ConversationStore\EIModels\EIModelIntent;
+use OpenDialogAi\ConversationEngine\Exceptions\NoMatchingIntentsException;
 use OpenDialogAi\Core\Attribute\AttributeInterface;
 use OpenDialogAi\Core\Conversation\Condition;
 use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\Scene;
+use OpenDialogAi\Core\Conversation\VirtualIntent;
 use OpenDialogAi\Core\Graph\Node\NodeDoesNotExistException;
 use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\UtteranceInterface;
@@ -89,34 +91,33 @@ class ConversationEngine implements ConversationEngineInterface
     /**
      * @param UserContext $userContext
      * @param UtteranceInterface $utterance
+     * @param bool $isVirtual
      * @return Intent[]
+     * @throws CurrentIntentNotSetException
+     * @throws EIModelCreatorException
      * @throws FieldNotSupported
      * @throws GuzzleException
      * @throws NodeDoesNotExistException
-     * @throws EIModelCreatorException
-     * @throws CurrentIntentNotSetException
      */
-    public function getNextIntents(UserContext $userContext, UtteranceInterface $utterance): array
+    public function getNextIntents(UserContext $userContext, UtteranceInterface $utterance, bool $isVirtual = false): array
     {
-        /* @var Conversation $ongoingConversation */
-        $ongoingConversation = $this->determineCurrentConversation($userContext, $utterance);
-        Log::debug(sprintf('Ongoing conversation determined as %s', $ongoingConversation->getId()));
+        if (!$isVirtual) {
+            /* @var Conversation $ongoingConversation */
+            $ongoingConversation = $this->determineCurrentConversation($userContext, $utterance);
+            Log::debug(sprintf('Ongoing conversation determined as %s', $ongoingConversation->getId()));
+        }
 
-        /* @var Scene $currentScene */
-        $currentScene = $userContext->getCurrentScene();
+        $nextIntent = $this->determineNextIntent($userContext);
 
-        /** @var EIModelIntent $currentIntent */
-        $currentIntent = $this->conversationStore->getEIModelIntentByUid($userContext->getUser()->getCurrentIntentUid());
+        if ($isVirtual) {
+            /** @var array $nextIntents */
+            $nextIntentsAttributeArray = ContextService::getConversationContext()->getAttributeValue('next_intents');
+            $nextIntentsAttributeArray[] = $nextIntent->getId();
+        } else {
+            $nextIntentsAttributeArray = [$nextIntent->getId()];
+        }
 
-        // If the current intent is said across scenes, we use 0 - otherwise we use its order in its scene.
-        $currentOrder = $currentIntent->getNextScene() ? 0 : $currentIntent->getOrder();
-
-        $possibleNextIntents = $currentScene->getNextPossibleBotIntents($currentOrder);
-        $filteredIntents = $this->filterByConditions($possibleNextIntents);
-
-        /* @var Intent $nextIntent */
-        $nextIntent = $filteredIntents->first()->value;
-        ContextService::saveAttribute('conversation.next_intents', [$nextIntent->getId()]);
+        ContextService::saveAttribute('conversation.next_intents', $nextIntentsAttributeArray);
 
         if ($nextIntent->causesAction()) {
             $inputActionAttributes = $nextIntent->getInputActionAttributeContexts();
@@ -125,13 +126,34 @@ class ConversationEngine implements ConversationEngineInterface
             $this->performIntentAction($userContext, $nextIntent, $inputActionAttributes, $outputActionAttributes);
         }
 
-        if ($nextIntent->completes()) {
-            $userContext->moveCurrentConversationToPast();
-        } else {
-            $userContext->setCurrentIntent($nextIntent);
+        /** @var Intent[] $nextIntents */
+        $nextIntents = [$nextIntent];
+
+        if ($nextIntent->getVirtualIntent()) {
+            try {
+                $userContext->setCurrentIntent($nextIntent);
+                $this->updateConversationFollowingVirtualUserInput($userContext, $nextIntent->getVirtualIntent());
+                $nextIntents = array_merge(
+                    $nextIntents,
+                    $this->getNextIntents($userContext, $utterance, true)
+                );
+            } catch (NoMatchingIntentsException $e) {
+                $utterance->setCallbackId(self::NO_MATCH);
+                return $this->getNextIntents($userContext, $utterance);
+            }
         }
 
-        return [$nextIntent];
+        if (!$isVirtual) {
+            $lastNextIntent = $nextIntents[array_key_last($nextIntents)];
+
+            if ($lastNextIntent->completes()) {
+                $userContext->moveCurrentConversationToPast();
+            } else {
+                $userContext->setCurrentIntent($lastNextIntent);
+            }
+        }
+
+        return $nextIntents;
     }
 
     /**
@@ -161,9 +183,9 @@ class ConversationEngine implements ConversationEngineInterface
 
             if ($userContext->currentSpeakerIsBot()) {
                 Log::debug(sprintf('Speaker was bot.'));
-                $ongoingConversation = $this->updateConversationFollowingUserInput($userContext, $utterance);
-
-                if (!isset($ongoingConversation)) {
+                try {
+                    $ongoingConversation = $this->updateConversationFollowingUserInput($userContext, $utterance);
+                } catch (NoMatchingIntentsException $e) {
                     Log::debug(sprintf('No intent for ongoing conversation matched, simulating a NoMatch.'));
                     $utterance->setCallbackId(self::NO_MATCH);
                     return self::determineCurrentConversation($userContext, $utterance);
@@ -196,32 +218,17 @@ class ConversationEngine implements ConversationEngineInterface
      * @param UserContext $userContext
      * @param UtteranceInterface $utterance
      * @return Conversation
-     * @throws ConversationStore\EIModelCreatorException
      * @throws CurrentIntentNotSetException
+     * @throws EIModelCreatorException
      * @throws GuzzleException
      * @throws NodeDoesNotExistException
-     * @throws EIModelCreatorException
      */
     public function updateConversationFollowingUserInput(
         UserContext $userContext,
         UtteranceInterface $utterance
-    ): ?Conversation {
-        /* @var Scene $currentScene */
-        $currentScene = $userContext->getCurrentScene();
+    ): Conversation {
+        $possibleNextIntents = $this->getNextPossibleUserIntentsFromCurrentIntent($userContext);
 
-        /* @var EIModelIntent $currentIntent */
-        $currentIntent = $userContext->getCurrentIntent();
-
-        if (!ContextService::hasContext('conversation')) {
-            ContextService::createContext('conversation');
-        }
-
-        ContextService::saveAttribute('conversation.current_scene', $currentScene->getId());
-        ContextService::saveAttribute('conversation.current_intent', $currentIntent->getIntentId());
-
-        // If the current intent is said across scenes, we use 0 - otherwise we use its order in its scene.
-        $currentOrder = $currentIntent->getNextScene() ? 0 : $currentIntent->getOrder();
-        $possibleNextIntents = $currentScene->getNextPossibleUserIntents($currentOrder);
         Log::debug(sprintf('There are %s possible next intents.', count($possibleNextIntents)));
 
         $defaultIntent = $this->interpreterService->getDefaultInterpreter()->interpret($utterance)[0];
@@ -256,8 +263,61 @@ class ConversationEngine implements ConversationEngineInterface
         Log::debug('No matching intent, moving conversation to past state');
         $userContext->moveCurrentConversationToPast();
         Log::debug('No match found, dropping out of current conversation.');
-        //@todo This should be an exception
-        return null;
+
+        throw new NoMatchingIntentsException();
+    }
+
+    /**
+     * @param UserContext $userContext
+     * @param VirtualIntent $virtualIntent
+     * @return Conversation
+     * @throws CurrentIntentNotSetException
+     * @throws EIModelCreatorException
+     * @throws GuzzleException
+     * @throws NodeDoesNotExistException
+     * @throws NoMatchingIntentsException
+     */
+    public function updateConversationFollowingVirtualUserInput(
+        UserContext $userContext,
+        VirtualIntent $virtualIntent
+    ): Conversation {
+        $possibleNextIntents = $this->getNextPossibleUserIntentsFromCurrentIntent($userContext);
+
+        $possibleNextIntents = $possibleNextIntents->filter(
+            function ($key, Intent $possibleIntent) use ($virtualIntent) {
+                return $possibleIntent->getId() === $virtualIntent->getId();
+            }
+        );
+
+        Log::debug(sprintf('There are %s possible next intents.', count($possibleNextIntents)));
+
+        $matchingIntents = $this->filterByConditions($possibleNextIntents);
+
+        if (count($matchingIntents) >= 1) {
+            Log::debug(sprintf('There are %s matching intents', count($matchingIntents)));
+
+            /** @var Intent $nextIntent */
+            $nextIntent = $matchingIntents->first()->value;
+            Log::debug(sprintf( 'Intent chosen as %s', $nextIntent->getId()));
+            $userContext->setCurrentIntent($nextIntent);
+
+            if ($nextIntent->causesAction()) {
+                $inputActionAttributes = $nextIntent->getInputActionAttributeContexts();
+                $outputActionAttributes = $nextIntent->getOutputActionAttributeContexts();
+
+                $this->performIntentAction($userContext, $nextIntent, $inputActionAttributes, $outputActionAttributes);
+            }
+
+            return $userContext->getCurrentConversation();
+        }
+
+        // What the user says does not match anything expected in the current conversation so complete it and
+        // pretend we received a no match intent.
+        Log::debug('No matching intent, moving conversation to past state');
+        $userContext->moveCurrentConversationToPast();
+        Log::debug('No match found, dropping out of current conversation.');
+
+        throw new NoMatchingIntentsException();
     }
 
     /**
@@ -637,5 +697,57 @@ class ConversationEngine implements ConversationEngineInterface
         }
 
         $this->persistContexts($contextsUpdated);
+    }
+
+    /**
+     * @param UserContext $userContext
+     * @return Intent
+     * @throws CurrentIntentNotSetException
+     * @throws EIModelCreatorException
+     */
+    private function determineNextIntent(UserContext $userContext): Intent
+    {
+        /* @var Scene $currentScene */
+        $currentScene = $userContext->getCurrentScene();
+
+        /** @var EIModelIntent $currentIntent */
+        $currentIntent = $this->conversationStore->getEIModelIntentByUid($userContext->getUser()->getCurrentIntentUid());
+
+        // If the current intent is said across scenes, we use 0 - otherwise we use its order in its scene.
+        $currentOrder = $currentIntent->getNextScene() ? 0 : $currentIntent->getOrder();
+
+        $possibleNextIntents = $currentScene->getNextPossibleBotIntents($currentOrder);
+        $filteredIntents = $this->filterByConditions($possibleNextIntents);
+
+        /* @var Intent $nextIntent */
+        $nextIntent = $filteredIntents->first()->value;
+        return $nextIntent;
+    }
+
+    /**
+     * @param UserContext $userContext
+     * @return Map
+     * @throws CurrentIntentNotSetException
+     * @throws EIModelCreatorException
+     */
+    private function getNextPossibleUserIntentsFromCurrentIntent(UserContext $userContext): Map
+    {
+        /* @var Scene $currentScene */
+        $currentScene = $userContext->getCurrentScene();
+
+        /* @var EIModelIntent $currentIntent */
+        $currentIntent = $userContext->getCurrentIntent();
+
+        if (!ContextService::hasContext('conversation')) {
+            ContextService::createContext('conversation');
+        }
+
+        ContextService::saveAttribute('conversation.current_scene', $currentScene->getId());
+        ContextService::saveAttribute('conversation.current_intent', $currentIntent->getIntentId());
+
+        // If the current intent is said across scenes, we use 0 - otherwise we use its order in its scene.
+        $currentOrder = $currentIntent->getNextScene() ? 0 : $currentIntent->getOrder();
+        $possibleNextIntents = $currentScene->getNextPossibleUserIntents($currentOrder);
+        return $possibleNextIntents;
     }
 }

--- a/src/ConversationEngine/Exceptions/NoMatchingIntentsException.php
+++ b/src/ConversationEngine/Exceptions/NoMatchingIntentsException.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace OpenDialogAi\ConversationEngine\Exceptions;
+
+
+use RuntimeException;
+
+class NoMatchingIntentsException extends RuntimeException
+{
+}

--- a/tests/Feature/NextIntentDetectionTest.php
+++ b/tests/Feature/NextIntentDetectionTest.php
@@ -222,6 +222,43 @@ class NextIntentDetectionTest extends TestCase
         $this->assertEquals($test2_2, $messages[2]->getText());
     }
 
+    public function testSingleVirtualIntents()
+    {
+        $openDialogController = resolve(OpenDialogController::class);
+
+        $this->createConversationWithVirtualIntent();
+
+        $conversationContext = ContextService::getConversationContext();
+
+        $utterance = UtteranceGenerator::generateChatOpenUtterance('intent.app.welcome');
+        $openDialogController->runConversation($utterance);
+        $this->assertEquals('intent.app.welcome', $conversationContext->getAttributeValue('interpreted_intent'));
+        $this->assertEquals('with_virtual_intent', $conversationContext->getAttributeValue('current_conversation'));
+        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
+        $this->assertCount(2, $conversationContext->getAttributeValue('next_intents'));
+        $this->assertEquals('intent.app.welcomeResponse', $conversationContext->getAttributeValue('next_intents')[0]);
+        $this->assertEquals('intent.app.endResponse', $conversationContext->getAttributeValue('next_intents')[1]);
+    }
+
+    public function testMultipleVirtualIntents()
+    {
+        $openDialogController = resolve(OpenDialogController::class);
+
+        $this->createConversationWithMultipleVirtualIntents();
+
+        $conversationContext = ContextService::getConversationContext();
+
+        $utterance = UtteranceGenerator::generateChatOpenUtterance('intent.app.welcome');
+        $openDialogController->runConversation($utterance);
+        $this->assertEquals('intent.app.welcome', $conversationContext->getAttributeValue('interpreted_intent'));
+        $this->assertEquals('with_virtual_intents', $conversationContext->getAttributeValue('current_conversation'));
+        $this->assertEquals('next_scene', $conversationContext->getAttributeValue('current_scene'));
+        $this->assertCount(3, $conversationContext->getAttributeValue('next_intents'));
+        $this->assertEquals('intent.app.welcomeResponse', $conversationContext->getAttributeValue('next_intents')[0]);
+        $this->assertEquals('intent.app.continueResponse', $conversationContext->getAttributeValue('next_intents')[1]);
+        $this->assertEquals('intent.app.nextResponse', $conversationContext->getAttributeValue('next_intents')[2]);
+    }
+
     public function getTestConversation()
     {
         return <<<EOT

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -618,6 +618,20 @@ EOT;
         }
     }
 
+    /**
+     * @return ConversationNode
+     */
+    public function createConversationWithMultipleVirtualIntents(): ConversationNode
+    {
+        $conversationMarkup = $this->getMarkupForConversationWithMultipleVirtualIntents();
+
+        try {
+            return $this->activateConversation($conversationMarkup);
+        } catch (Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
     public function getMarkupForConversationWithVirtualIntent(): string
     {
         /** @lang yaml */
@@ -637,6 +651,58 @@ conversation:
               i: intent.app.continue
           - b:
               i: intent.app.endResponse
+              completes: true
+EOT;
+    }
+
+    public function getMarkupForConversationWithMultipleVirtualIntents(): string
+    {
+        /** @lang yaml */
+        return <<<EOT
+conversation:
+  id: with_virtual_intents
+  scenes:
+    opening_scene:
+      intents:
+          - u:
+              i: intent.app.welcome
+          - b:
+              i: intent.app.welcomeResponse
+              u_virtual:
+                i: intent.app.continue
+              scene: next_scene
+    next_scene:
+      intents:
+          - u:
+              i: intent.app.continue
+              conditions:
+                - condition:
+                    operation: is_set
+                    attributes:
+                      attribute: user.test
+              scene: test_scene
+          - u:
+              i: intent.app.continue
+              conditions:
+                - condition:
+                    operation: is_not_set
+                    attributes:
+                      attribute: user.test
+          - b:
+              i: intent.app.continueResponse
+              u_virtual:
+                i: intent.app.continue
+          - u:
+              i: intent.app.continue
+          - b:
+              i: intent.app.nextResponse
+              completes: true
+    test_scene:
+      intents:
+          - u:
+              i: intent.app.continue
+          - b:
+              i: intent.app.testResponse
               completes: true
 EOT;
     }


### PR DESCRIPTION
This PR adds support for virtual incoming intents and is dependent on work in #268 & #271. 

## Example

Virtual intents allow a conversation designer to specify that a given intent will simulate another intent. In the example below, a user would begin the conversation by saying the `intent.app.welcome` intent. After this they would, as usual, receive the `intent.app.welcomeResponse`, but also the `intent.app.endResponse`. This second intent is triggered by the `u_virtual` directive on the `intent.app.welcomeResponse` intent. The directive specifies the id of the intent to simulate, which matches the id of the succeeding incoming intent. From a chatbot user's perspective they receive two sets of messages, one from each intent.

```yaml
conversation:
  id: with_virtual_intent
  scenes:
    opening_scene:
      intents:
          - u:
              i: intent.app.welcome
          - b:
              i: intent.app.welcomeResponse
              u_virtual:
                i: intent.app.continue
          - u:
              i: intent.app.continue
          - b:
              i: intent.app.endResponse
              completes: true
```

## Changes
### ConversationEngine
The `getNextIntents` method has been changed to allow for it to be called recursively. The changes are premised by a boolean parameter (`$isVirtual`), which is false by default. When a recursive call is made, the value is passed as true. This allows us to know whether we are dealing with the initial call or a recursive call to the method.

When an outgoing intent that has a virtual incoming intent is triggered, the engine checks the following incoming intents and those that don't match the id of the virtual intent will be filtered out. The remaining will be filtered by their conditions. If no intents survive the filtering, then (currently) this PR returns a NoMatchResponse along with the originally triggered outgoing intent. It doesn't seem like this would ever happen unless the conversation was incorrectly design. It may be worth considering adding validation for this in the conversation editor, as well as considering whether returning a NoMatch in this way is the desired behaviour.

## Before merging
- [x] Update the base branch to the 'develop' branch
- [x] Resolve merge conflicts