### PR TITLE
allows serialized() method to return a null value. An attribute can contain a null value

### DIFF
--- a/src/Attribute/AbstractAttribute.php
+++ b/src/Attribute/AbstractAttribute.php
@@ -83,7 +83,7 @@ abstract class AbstractAttribute implements AttributeInterface
     /**
      * @return string
      */
-    public function serialized(): string
+    public function serialized(): ?string
     {
         return $this->value;
     }

--- a/src/Attribute/ArrayAttribute.php
+++ b/src/Attribute/ArrayAttribute.php
@@ -69,12 +69,4 @@ class ArrayAttribute extends AbstractAttribute
     {
         return $this->value;
     }
-
-    /**
-     * @return string
-     */
-    public function serialized(): string
-    {
-        return $this->value;
-    }
 }

--- a/src/Attribute/AttributeInterface.php
+++ b/src/Attribute/AttributeInterface.php
@@ -41,5 +41,5 @@ interface AttributeInterface
      *
      * @return string
      */
-    public function serialized(): string;
+    public function serialized(): ?string;
 }


### PR DESCRIPTION
The `serialized` method is called when persisting attributes to graph and expects a serialized version of the attribute to be returned that can be deserialized when loading the attribute again.

The method is set up to return a string, but since the attribute could have a null value, the serialization could also be null.

The change I have made has allowed the method to return null.

Another option could be for the method to check if there is a value, and if not return an empty string.