### PR TITLE
Add Util methods to encode/decode

### DIFF
--- a/src/Attribute/ArrayAttribute.php
+++ b/src/Attribute/ArrayAttribute.php
@@ -32,10 +32,10 @@ class ArrayAttribute extends AbstractAttribute
     public function setValue($value)
     {
         if (is_string($value)) {
-            $value = json_decode(htmlspecialchars_decode($value), true);
+            $value = Util::decode($value);
         }
 
-        $this->value = htmlspecialchars(json_encode($value), ENT_QUOTES);
+        $this->value = Util::encode($value);
     }
 
     /**
@@ -46,10 +46,10 @@ class ArrayAttribute extends AbstractAttribute
     public function getValue(array $index = [])
     {
         if (!$index) {
-            return json_decode(htmlspecialchars_decode($this->value), true);
+            return Util::decode($this->value);
         }
 
-        $arrayValue = json_decode(htmlspecialchars_decode($this->value), true);
+        $arrayValue = Util::decode($this->value);
 
         try {
             foreach ($index as $key => $value) {

--- a/src/Attribute/Composite/AbstractAttributeCollection.php
+++ b/src/Attribute/Composite/AbstractAttributeCollection.php
@@ -4,6 +4,7 @@ namespace OpenDialogAi\Core\Attribute\Composite;
 
 use OpenDialogAi\ContextEngine\Facades\AttributeResolver;
 use OpenDialogAi\Core\Attribute\AttributeInterface;
+use OpenDialogAi\Core\Attribute\Util;
 
 /**
  * An abstract class that is used to populate CompositeAttributes.
@@ -66,7 +67,7 @@ abstract class AbstractAttributeCollection implements AttributeCollectionInterfa
             $serializedResult[] = ['id' => $attribute->getId(), 'value' => $attribute->getValue()];
         }
 
-        return  htmlspecialchars(json_encode($serializedResult), ENT_QUOTES);
+        return Util::encode($serializedResult);
     }
 
     /**
@@ -84,7 +85,7 @@ abstract class AbstractAttributeCollection implements AttributeCollectionInterfa
      */
     private function jsonDeserialize($input) : array
     {
-        $arrayOfAttributes = json_decode(htmlspecialchars_decode($input, ENT_QUOTES), true);
+        $arrayOfAttributes = Util::decode($input);
         $resultAttributes = [];
 
         foreach ($arrayOfAttributes as $attribute) {

--- a/src/Attribute/Util.php
+++ b/src/Attribute/Util.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenDialogAi\Core\Attribute;
+
+/**
+ * Collection of Util/Helper functions.
+ *
+ */
+class Util
+{
+    public static function decode($json)
+    {
+        return json_decode(htmlspecialchars_decode(
+            $json,
+            ENT_QUOTES
+        ), true);
+    }
+
+    public static function encode($array)
+    {
+        return htmlspecialchars(json_encode($array), ENT_QUOTES);
+    }
+}

--- a/src/Attribute/test/ExampleAbstractAttributeCollection.php
+++ b/src/Attribute/test/ExampleAbstractAttributeCollection.php
@@ -5,6 +5,7 @@ namespace OpenDialogAi\Core\Attribute\test;
 use OpenDialogAi\Core\Attribute\ArrayAttribute;
 use OpenDialogAi\Core\Attribute\Composite\AbstractAttributeCollection;
 use OpenDialogAi\Core\Attribute\IntAttribute;
+use OpenDialogAi\Core\Attribute\Util;
 
 /**
  * A composite attribute collection containing other attribute types.
@@ -34,7 +35,7 @@ class ExampleAbstractAttributeCollection extends AbstractAttributeCollection
                 'value' => $attribute->toString()
             ];
         }
-        return json_encode($result);
+        return Util::encode($result);
     }
 
 

--- a/src/Attribute/test/SecondAbstractAttributeCollection.php
+++ b/src/Attribute/test/SecondAbstractAttributeCollection.php
@@ -5,6 +5,7 @@ namespace OpenDialogAi\Core\Attribute\test;
 use OpenDialogAi\Core\Attribute\ArrayAttribute;
 use OpenDialogAi\Core\Attribute\Composite\AbstractAttributeCollection;
 use OpenDialogAi\Core\Attribute\IntAttribute;
+use OpenDialogAi\Core\Attribute\Util;
 
 /**
  * A composite attribute collection containing other attribute types.
@@ -36,7 +37,7 @@ class SecondAbstractAttributeCollection extends AbstractAttributeCollection
                 'value' => $attribute->toString()
             ];
         }
-        return json_encode($result);
+        return Util::encode($result);
     }
 
 


### PR DESCRIPTION
**Description**
- Changes: Utils method for encoding/decoding in Attributes
- Reason: DRY, Single source of truth for encoding/decoding format in Attributes, reduce noise in codebase