### PR TITLE
Repeating intent data structures

### DIFF
--- a/src/Attribute/BooleanAttribute.php
+++ b/src/Attribute/BooleanAttribute.php
@@ -2,8 +2,6 @@
 
 namespace OpenDialogAi\Core\Attribute;
 
-use Illuminate\Support\Facades\Log;
-
 /**
  * A BooleanAttribute implementation.
  */

--- a/src/ContextEngine/config/opendialog-contextengine.php
+++ b/src/ContextEngine/config/opendialog-contextengine.php
@@ -1,35 +1,43 @@
 <?php
 
-return [
-    'supported_attributes' => [
-        'attribute_name'   => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'attribute_value' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'callback_value' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'context' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'ei_type' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'email' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'external_id' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'first_name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'full_name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'id' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'last_name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'age' => \OpenDialogAi\Core\Attribute\IntAttribute::class,
-        'name' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'operation' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'timestamp' => \OpenDialogAi\Core\Attribute\IntAttribute::class,
-        'last_seen' => OpenDialogAi\Core\Attribute\TimestampAttribute::class,
-        'first_seen' => OpenDialogAi\Core\Attribute\TimestampAttribute::class,
+use OpenDialogAi\Core\Conversation\Model;
 
+return [
+    'supported_attributes' => array(
+
+        'attribute_name'  => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'attribute_value' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'callback_value'  => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        Model::CONTEXT    => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        Model::EI_TYPE    => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'operation'       => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'timestamp'       => \OpenDialogAi\Core\Attribute\IntAttribute::class,
+
+        // QnA Interpreter
         'qna_answer' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
 
+        // Conversation Context
         'current_conversation' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'current_scene' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'current_intent' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'interpreted_intent' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
-        'next_intents' => \OpenDialogAi\Core\Attribute\ArrayAttribute::class,
+        'current_scene'        => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'current_intent'       => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'interpreted_intent'   => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'next_intents'         => \OpenDialogAi\Core\Attribute\ArrayAttribute::class,
+
+        // Chatbot User
+        'email'       => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'external_id' => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'first_name'  => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'full_name'   => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'id'          => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'last_name'   => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'age'         => \OpenDialogAi\Core\Attribute\IntAttribute::class,
+        'name'        => \OpenDialogAi\Core\Attribute\StringAttribute::class,
+        'last_seen'   => OpenDialogAi\Core\Attribute\TimestampAttribute::class,
+        'first_seen'  => OpenDialogAi\Core\Attribute\TimestampAttribute::class,
 
         // Intents
-        \OpenDialogAi\Core\Conversation\Model::CONFIDENCE => \OpenDialogAi\Core\Attribute\FloatAttribute::class,
-        \OpenDialogAi\Core\Conversation\Model::COMPLETES => \OpenDialogAi\Core\Attribute\BooleanAttribute::class
-    ],
+        Model::CONFIDENCE => \OpenDialogAi\Core\Attribute\FloatAttribute::class,
+        Model::COMPLETES  => \OpenDialogAi\Core\Attribute\BooleanAttribute::class,
+        Model::REPEATING  => \OpenDialogAi\Core\Attribute\BooleanAttribute::class
+    ),
 ];

--- a/src/Conversation/Intent.php
+++ b/src/Conversation/Intent.php
@@ -8,7 +8,6 @@ use OpenDialogAi\ContextEngine\ContextParser;
 use OpenDialogAi\ContextEngine\Facades\AttributeResolver;
 use OpenDialogAi\Core\Attribute\FloatAttribute;
 use OpenDialogAi\Core\Attribute\IntAttribute;
-use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Attribute\UnsupportedAttributeTypeException;
 use OpenDialogAi\Core\Graph\Node\NodeDoesNotExistException;
 
@@ -41,8 +40,8 @@ class Intent extends NodeWithConditions
     public function __construct($id, $completes = false)
     {
         parent::__construct($id);
-        $this->addAttribute(new StringAttribute(Model::EI_TYPE, Model::INTENT));
-        $this->addAttribute(new StringAttribute(Model::REPEATING, false));
+        $this->addAttribute(AttributeResolver::getAttributeFor(Model::EI_TYPE, Model::INTENT));
+        $this->addAttribute(AttributeResolver::getAttributeFor(Model::REPEATING, false));
 
         $this->setCompletesAttribute($completes);
     }

--- a/src/Conversation/Intent.php
+++ b/src/Conversation/Intent.php
@@ -23,7 +23,8 @@ class Intent extends NodeWithConditions
         Model::EI_TYPE,
         Model::COMPLETES,
         Model::ORDER,
-        Model::CONFIDENCE
+        Model::CONFIDENCE,
+        Model::REPEATING
     ];
 
     private $completes = false;
@@ -41,6 +42,7 @@ class Intent extends NodeWithConditions
     {
         parent::__construct($id);
         $this->addAttribute(new StringAttribute(Model::EI_TYPE, Model::INTENT));
+        $this->addAttribute(new StringAttribute(Model::REPEATING, false));
 
         $this->setCompletesAttribute($completes);
     }
@@ -503,8 +505,19 @@ class Intent extends NodeWithConditions
             ->addFacet(ModelFacets::CREATED_AT, $createdAt);
     }
 
-    public function isRepeating()
+    /**
+     * @return bool
+     */
+    public function isRepeating(): bool
     {
-        return false;
+        return $this->getAttributeValue(Model::REPEATING);
+    }
+
+    /**
+     * @param bool $repeating
+     */
+    public function setRepeating(bool $repeating)
+    {
+        $this->setAttribute(Model::REPEATING, $repeating);
     }
 }

--- a/src/Conversation/Intent.php
+++ b/src/Conversation/Intent.php
@@ -502,4 +502,9 @@ class Intent extends NodeWithConditions
         $this->createOutgoingEdge(Model::FOLLOWED_BY, $toIntent)
             ->addFacet(ModelFacets::CREATED_AT, $createdAt);
     }
+
+    public function isRepeating()
+    {
+        return false;
+    }
 }

--- a/src/Conversation/Model.php
+++ b/src/Conversation/Model.php
@@ -71,6 +71,7 @@ class Model
     const ORDER = 'core.attribute.order';
     const COMPLETES = 'core.attribute.completes';
     const CONFIDENCE = 'core.attribute.confidence';
+    const REPEATING = 'core.attribute.repeating';
     const CONTEXT = 'context';
     const ATTRIBUTES = 'attributes';
     const OPERATION = 'operation';

--- a/src/ConversationBuilder/Conversation.php
+++ b/src/ConversationBuilder/Conversation.php
@@ -363,6 +363,7 @@ class Conversation extends Model
         $inputActionAttributes = null;
         $outputActionAttributes = null;
         $virtualIntentId = null;
+        $repeating = false;
 
         if (is_array($intentValue)) {
             $intentLabel = $intentValue['i'];
@@ -372,6 +373,7 @@ class Conversation extends Model
             $conditions = $intentValue['conditions'] ?? null;
             $intentSceneId = $intentValue['scene'] ?? null;
             $expectedAttributes = $intentValue['expected_attributes'] ?? null;
+            $repeating = $intentValue['repeating'] ?? false;
 
             if (isset($intentValue['action']) && is_array($intentValue['action'])) {
                 $actionLabel = $intentValue['action']['id'] ?? null;
@@ -431,6 +433,10 @@ class Conversation extends Model
 
         if ($virtualIntentId) {
             $intentNode->addVirtualIntent(new VirtualIntent($virtualIntentId));
+        }
+
+        if ($repeating) {
+            $intentNode->setRepeating(true);
         }
 
         return $intentNode;

--- a/src/ConversationBuilder/tests/ConversationBuilderTest.php
+++ b/src/ConversationBuilder/tests/ConversationBuilderTest.php
@@ -586,15 +586,19 @@ class ConversationBuilderTest extends TestCase
         $openingScene = $conversation->getOpeningScenes()->first()->value;
 
         $this->assertCount(3, $openingScene->getIntentsSaidByUser());
-        $this->assertCount(3, $openingScene->getIntentsSaidByBot());
+        $this->assertCount(2, $openingScene->getIntentsSaidByBot());
 
         /** @var Intent $secondUserIntent */
         $secondUserIntent = $openingScene->getIntentsSaidByUserInOrder()->skip(1)->value;
+
+        /** @var Intent $thirdUserIntent */
+        $thirdUserIntent = $openingScene->getIntentsSaidByUserInOrder()->skip(2)->value;
 
         /** @var Intent $secondBotIntent */
         $secondBotIntent = $openingScene->getIntentsSaidByBotInOrder()->skip(1)->value;
 
         $this->assertTrue($secondUserIntent->isRepeating());
+        $this->assertFalse($thirdUserIntent->isRepeating());
         $this->assertFalse($secondBotIntent->isRepeating());
     }
 }

--- a/src/ConversationBuilder/tests/ConversationBuilderTest.php
+++ b/src/ConversationBuilder/tests/ConversationBuilderTest.php
@@ -567,7 +567,7 @@ class ConversationBuilderTest extends TestCase
         $this->assertCount(2, $openingScene->getIntentsSaidByBot());
 
         /** @var Intent $firstBotIntent */
-        $firstBotIntent = $openingScene->getIntentsSaidByBot()->first()->value;
+        $firstBotIntent = $openingScene->getIntentsSaidByBotInOrder()->first()->value;
 
         $this->assertEquals('intent.app.welcomeResponse', $firstBotIntent->getId());
 
@@ -580,19 +580,19 @@ class ConversationBuilderTest extends TestCase
 
     public function testRepeatingIntents()
     {
-        $conversation = $this->createConversationWithVirtualIntent();
+        $conversation = $this->createConversationWithRepeatingIntent();
 
         /** @var Scene $openingScene */
         $openingScene = $conversation->getOpeningScenes()->first()->value;
 
-        $this->assertCount(2, $openingScene->getIntentsSaidByUser());
-        $this->assertCount(2, $openingScene->getIntentsSaidByBot());
+        $this->assertCount(3, $openingScene->getIntentsSaidByUser());
+        $this->assertCount(3, $openingScene->getIntentsSaidByBot());
 
         /** @var Intent $secondUserIntent */
-        $secondUserIntent = $openingScene->getIntentsSaidByUser()->skip(1)->value;
+        $secondUserIntent = $openingScene->getIntentsSaidByUserInOrder()->skip(1)->value;
 
         /** @var Intent $secondBotIntent */
-        $secondBotIntent = $openingScene->getIntentsSaidByBot()->skip(1)->value;
+        $secondBotIntent = $openingScene->getIntentsSaidByBotInOrder()->skip(1)->value;
 
         $this->assertTrue($secondUserIntent->isRepeating());
         $this->assertFalse($secondBotIntent->isRepeating());

--- a/src/ConversationBuilder/tests/ConversationBuilderTest.php
+++ b/src/ConversationBuilder/tests/ConversationBuilderTest.php
@@ -577,4 +577,24 @@ class ConversationBuilderTest extends TestCase
         $this->assertNotNull($virtualIntent);
         $this->assertEquals('intent.app.continue', $virtualIntent->getId());
     }
+
+    public function testRepeatingIntents()
+    {
+        $conversation = $this->createConversationWithVirtualIntent();
+
+        /** @var Scene $openingScene */
+        $openingScene = $conversation->getOpeningScenes()->first()->value;
+
+        $this->assertCount(2, $openingScene->getIntentsSaidByUser());
+        $this->assertCount(2, $openingScene->getIntentsSaidByBot());
+
+        /** @var Intent $secondUserIntent */
+        $secondUserIntent = $openingScene->getIntentsSaidByUser()->skip(1)->value;
+
+        /** @var Intent $secondBotIntent */
+        $secondBotIntent = $openingScene->getIntentsSaidByBot()->skip(1)->value;
+
+        $this->assertTrue($secondUserIntent->isRepeating());
+        $this->assertFalse($secondBotIntent->isRepeating());
+    }
 }

--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -9,9 +9,9 @@ use Illuminate\Support\Facades\Log;
 use OpenDialogAi\ActionEngine\Actions\ActionResult;
 use OpenDialogAi\ActionEngine\Exceptions\ActionNotAvailableException;
 use OpenDialogAi\ActionEngine\Service\ActionEngineInterface;
+use OpenDialogAi\ContextEngine\ContextManager\ContextInterface;
 use OpenDialogAi\ContextEngine\Contexts\Intent\IntentContext;
 use OpenDialogAi\ContextEngine\Contexts\User\CurrentIntentNotSetException;
-use OpenDialogAi\ContextEngine\ContextManager\ContextInterface;
 use OpenDialogAi\ContextEngine\Contexts\User\UserContext;
 use OpenDialogAi\ContextEngine\Exceptions\ContextDoesNotExistException;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
@@ -100,61 +100,33 @@ class ConversationEngine implements ConversationEngineInterface
      * @throws GuzzleException
      * @throws NodeDoesNotExistException
      */
-    public function getNextIntents(UserContext $userContext, UtteranceInterface $utterance, bool $isVirtual = false): array
+    public function getNextIntents(UserContext $userContext, UtteranceInterface $utterance): array
     {
-        if (!$isVirtual) {
-            /* @var Conversation $ongoingConversation */
-            $ongoingConversation = $this->determineCurrentConversation($userContext, $utterance);
-            Log::debug(sprintf('Ongoing conversation determined as %s', $ongoingConversation->getId()));
-        }
+        /* @var Conversation $ongoingConversation */
+        $ongoingConversation = $this->determineCurrentConversation($userContext, $utterance);
+        Log::debug(sprintf('Ongoing conversation determined as %s', $ongoingConversation->getId()));
 
-        $nextIntent = $this->determineNextIntent($userContext);
+        $isRepeating = $userContext->getCurrentIntent()->getRepeating();
+        $precedingIntent = $this->getConversationStore()->getPrecedingIntent(
+            $userContext->getCurrentIntent()->getIntentUid()
+        );
 
-        if ($isVirtual) {
-            /** @var array $nextIntents */
-            $nextIntentsAttributeArray = ContextService::getConversationContext()->getAttributeValue('next_intents');
-            $nextIntentsAttributeArray[] = $nextIntent->getId();
+        ContextService::saveAttribute('conversation.next_intents', []);
+        $followingIntents = $this->getAndHandleFollowingIntents($userContext, $utterance);
+
+        $lastIntent = $followingIntents[array_key_last($followingIntents)];
+
+        if ($isRepeating) {
+            $userContext->setCurrentIntent($precedingIntent);
         } else {
-            $nextIntentsAttributeArray = [$nextIntent->getId()];
-        }
-
-        ContextService::saveAttribute('conversation.next_intents', $nextIntentsAttributeArray);
-
-        if ($nextIntent->causesAction()) {
-            $inputActionAttributes = $nextIntent->getInputActionAttributeContexts();
-            $outputActionAttributes = $nextIntent->getOutputActionAttributeContexts();
-
-            $this->performIntentAction($userContext, $nextIntent, $inputActionAttributes, $outputActionAttributes);
-        }
-
-        /** @var Intent[] $nextIntents */
-        $nextIntents = [$nextIntent];
-
-        if ($nextIntent->getVirtualIntent()) {
-            try {
-                $userContext->setCurrentIntent($nextIntent);
-                $this->updateConversationFollowingVirtualUserInput($userContext, $nextIntent->getVirtualIntent());
-                $nextIntents = array_merge(
-                    $nextIntents,
-                    $this->getNextIntents($userContext, $utterance, true)
-                );
-            } catch (NoMatchingIntentsException $e) {
-                $utterance->setCallbackId(self::NO_MATCH);
-                return $this->getNextIntents($userContext, $utterance);
-            }
-        }
-
-        if (!$isVirtual) {
-            $lastNextIntent = $nextIntents[array_key_last($nextIntents)];
-
-            if ($lastNextIntent->completes()) {
+            if ($lastIntent->completes()) {
                 $userContext->moveCurrentConversationToPast();
             } else {
-                $userContext->setCurrentIntent($lastNextIntent);
+                $userContext->setCurrentIntent($lastIntent);
             }
         }
 
-        return $nextIntents;
+        return $followingIntents;
     }
 
     /**
@@ -249,10 +221,7 @@ class ConversationEngine implements ConversationEngineInterface
             $this->storeIntentAttributes($nextIntent);
 
             if ($nextIntent->causesAction()) {
-                $inputActionAttributes = $nextIntent->getInputActionAttributeContexts();
-                $outputActionAttributes = $nextIntent->getOutputActionAttributeContexts();
-
-                $this->performIntentAction($userContext, $nextIntent, $inputActionAttributes, $outputActionAttributes);
+                $this->performIntentAction($userContext, $nextIntent);
             }
 
             return $userContext->getCurrentConversation();
@@ -302,10 +271,7 @@ class ConversationEngine implements ConversationEngineInterface
             $userContext->setCurrentIntent($nextIntent);
 
             if ($nextIntent->causesAction()) {
-                $inputActionAttributes = $nextIntent->getInputActionAttributeContexts();
-                $outputActionAttributes = $nextIntent->getOutputActionAttributeContexts();
-
-                $this->performIntentAction($userContext, $nextIntent, $inputActionAttributes, $outputActionAttributes);
+                $this->performIntentAction($userContext, $nextIntent);
             }
 
             return $userContext->getCurrentConversation();
@@ -380,10 +346,7 @@ class ConversationEngine implements ConversationEngineInterface
         ContextService::saveAttribute('conversation.current_scene', 'opening_scene');
 
         if ($currentIntent->causesAction()) {
-            $inputActionAttributes = $intent->getInputActionAttributeContexts();
-            $outputActionAttributes = $intent->getOutputActionAttributeContexts();
-
-            $this->performIntentAction($userContext, $currentIntent, $inputActionAttributes, $outputActionAttributes);
+            $this->performIntentAction($userContext, $currentIntent);
         }
 
         // For this intent get the matching conversation - we are pulling this back out from the user
@@ -593,16 +556,10 @@ class ConversationEngine implements ConversationEngineInterface
      *
      * @param UserContext $userContext
      * @param Intent $nextIntent
-     * @param Map $inputActionAttributes
-     * @param Map $outputActionAttributes
      * @throws NodeDoesNotExistException
      */
-    public function performIntentAction(
-        UserContext $userContext,
-        Intent $nextIntent,
-        Map $inputActionAttributes,
-        Map $outputActionAttributes
-    ): void {
+    public function performIntentAction(UserContext $userContext, Intent $nextIntent): void
+    {
         Log::debug(
             sprintf(
                 'Current intent %s causes action %s',
@@ -612,6 +569,8 @@ class ConversationEngine implements ConversationEngineInterface
         );
 
         $action = $nextIntent->getAction();
+        $inputActionAttributes = $nextIntent->getInputActionAttributeContexts();
+        $outputActionAttributes = $nextIntent->getOutputActionAttributeContexts();
 
         try {
             /* @var ActionResult $actionResult */
@@ -750,6 +709,7 @@ class ConversationEngine implements ConversationEngineInterface
 
         /* @var Intent $nextIntent */
         $nextIntent = $filteredIntents->first()->value;
+
         return $nextIntent;
     }
 
@@ -778,5 +738,81 @@ class ConversationEngine implements ConversationEngineInterface
         $currentOrder = $currentIntent->getNextScene() ? 0 : $currentIntent->getOrder();
         $possibleNextIntents = $currentScene->getNextPossibleUserIntents($currentOrder);
         return $possibleNextIntents;
+    }
+
+    /**
+     * Based on what user's current intent, determine the following bot intent, handle that intent and iterate for
+     * following virtual intents.
+     *
+     * @param UserContext $userContext
+     * @param UtteranceInterface $utterance
+     * @return Intent[]
+     * @throws CurrentIntentNotSetException
+     * @throws EIModelCreatorException
+     * @throws FieldNotSupported
+     * @throws GuzzleException
+     * @throws NodeDoesNotExistException
+     */
+    private function getAndHandleFollowingIntents(UserContext $userContext, UtteranceInterface $utterance): array
+    {
+        $nextIntent = $this->determineNextIntent($userContext);
+
+        $this->handleIntent($userContext, $nextIntent);
+
+        return $this->getVirtualIntents($nextIntent, $userContext, $utterance);
+    }
+
+    /**
+     * Gets any following virtual intents of an intent and updates the conversation iteratively for each virtual intent
+     *
+     * @param Intent $nextIntent
+     * @param UserContext $userContext
+     * @param UtteranceInterface $utterance
+     * @return Intent[]
+     * @throws CurrentIntentNotSetException
+     * @throws EIModelCreatorException
+     * @throws FieldNotSupported
+     * @throws GuzzleException
+     * @throws NodeDoesNotExistException
+     */
+    private function getVirtualIntents(Intent $nextIntent, UserContext $userContext, UtteranceInterface $utterance): array
+    {
+        $nextIntents = [$nextIntent];
+
+        if ($nextIntent->getVirtualIntent()) {
+            try {
+                $userContext->setCurrentIntent($nextIntent);
+                $this->updateConversationFollowingVirtualUserInput($userContext, $nextIntent->getVirtualIntent());
+
+                $nextIntents = array_merge(
+                    $nextIntents,
+                    $this->getAndHandleFollowingIntents($userContext, $utterance)
+                );
+            } catch (NoMatchingIntentsException $e) {
+                $utterance->setCallbackId(self::NO_MATCH);
+                return $this->getAndHandleFollowingIntents($userContext, $utterance);
+            }
+        }
+
+        return $nextIntents;
+    }
+
+    /**
+     * Handle any operations that must be completed for each returned outgoing intent
+     *
+     * @param UserContext $userContext
+     * @param Intent $nextIntent
+     * @throws NodeDoesNotExistException
+     */
+    private function handleIntent(UserContext $userContext, Intent $nextIntent): void
+    {
+        /** @var array $nextIntents */
+        $nextIntentsAttributeArray = ContextService::getConversationContext()->getAttributeValue('next_intents');
+        $nextIntentsAttributeArray[] = $nextIntent->getId();
+        ContextService::saveAttribute('conversation.next_intents', $nextIntentsAttributeArray);
+
+        if ($nextIntent->causesAction()) {
+            $this->performIntentAction($userContext, $nextIntent);
+        }
     }
 }

--- a/src/ConversationEngine/ConversationStore/ConversationQueryFactoryInterface.php
+++ b/src/ConversationEngine/ConversationStore/ConversationQueryFactoryInterface.php
@@ -58,4 +58,10 @@ interface ConversationQueryFactoryInterface
      * @return DGraphQuery
      */
     public static function hasConversationBeenUsed(string $name): DGraphQuery;
+
+    /**
+     * @param $intentUid
+     * @return DGraphQuery
+     */
+    public static function getPrecedingIntent($intentUid): DGraphQuery;
 }

--- a/src/ConversationEngine/ConversationStore/ConversationStoreInterface.php
+++ b/src/ConversationEngine/ConversationStore/ConversationStoreInterface.php
@@ -107,4 +107,10 @@ interface ConversationStoreInterface
      * @return bool
      */
     public function hasConversationBeenUsed(string $name): bool;
+
+    /**
+     * @param $intentUid
+     * @return Intent|null
+     */
+    public function getPrecedingIntent($intentUid): ?Intent;
 }

--- a/src/ConversationEngine/ConversationStore/DGraphConversationQueryFactory.php
+++ b/src/ConversationEngine/ConversationStore/DGraphConversationQueryFactory.php
@@ -329,4 +329,18 @@ class DGraphConversationQueryFactory implements ConversationQueryFactoryInterfac
                 Model::UID
             ]);
     }
+
+    /**
+     * @param $intentUid
+     * @return DGraphQuery
+     */
+    public static function getPrecedingIntent($intentUid): DGraphQuery
+    {
+        return (new DGraphQuery())
+            ->uid($intentUid)
+            ->setQueryGraph([
+                Model::UID,
+                Model::PRECEDED_BY => self::getIntentGraph()
+            ]);
+    }
 }

--- a/src/ConversationEngine/ConversationStore/DGraphConversationQueryFactory.php
+++ b/src/ConversationEngine/ConversationStore/DGraphConversationQueryFactory.php
@@ -238,6 +238,7 @@ class DGraphConversationQueryFactory implements ConversationQueryFactoryInterfac
                     ModelFacets::CREATED_AT
                 ]
             ],
+            Model::REPEATING,
             Model::HAS_INTERPRETER => self::getInterpreterGraph(),
             Model::HAS_EXPECTED_ATTRIBUTE => self::getExpectedAttributesGraph(),
             Model::HAS_CONDITION => self::getConditionGraph(),

--- a/src/ConversationEngine/ConversationStore/EIModelToGraphConverter.php
+++ b/src/ConversationEngine/ConversationStore/EIModelToGraphConverter.php
@@ -134,6 +134,7 @@ class EIModelToGraphConverter
         $intent->setCompletesAttribute($intentData->getCompletes());
         $intent->setConfidence($intentData->getConfidence());
         $intent->setOrderAttribute($intentData->getOrder());
+        $intent->setRepeating($intentData->getRepeating());
 
         /* @var Pair $action */
         $actionPair = $intentData->getAction();

--- a/src/ConversationEngine/ConversationStore/EIModels/EIModelIntent.php
+++ b/src/ConversationEngine/ConversationStore/EIModels/EIModelIntent.php
@@ -34,6 +34,9 @@ class EIModelIntent extends EIModelWithConditions
 
     private $followedByCreatedAt;
 
+    /** @var bool $repeating */
+    private $repeating;
+
     /* @var Pair $action */
     private $action;
 
@@ -97,6 +100,7 @@ class EIModelIntent extends EIModelWithConditions
         $intent->setIntentUid($intentResponse[Model::UID]);
         $intent->setOrder($intentResponse[Model::ORDER]);
         $intent->setConfidence(isset($intentResponse[Model::CONFIDENCE]) ? $intentResponse[Model::CONFIDENCE] : 1);
+        $intent->setRepeating(isset($intentResponse[Model::REPEATING]) ? $intentResponse[Model::REPEATING] : false);
 
         if (!is_null($additionalParameter)) {
             // If there is an additional parameter it means that $response contains the conversation data
@@ -552,5 +556,21 @@ class EIModelIntent extends EIModelWithConditions
     public function setFollowedByCreatedAt($followedByCreatedAt): void
     {
         $this->followedByCreatedAt = $followedByCreatedAt;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getRepeating(): bool
+    {
+        return $this->repeating;
+    }
+
+    /**
+     * @param bool $repeating
+     */
+    public function setRepeating(bool $repeating): void
+    {
+        $this->repeating = $repeating;
     }
 }

--- a/src/Graph/DGraph/DGraphClient.php
+++ b/src/Graph/DGraph/DGraphClient.php
@@ -348,6 +348,7 @@ class DGraphClient
             <conversation_version>: int .
             <core.attribute.completes>: default .
             <core.attribute.order>: default .
+            <core.attribute.repeating>: default .
             <ei_type>: string @index(exact) .
             <followed_by>: uid @reverse .
             <has_bot_participant>: [uid] @reverse .
@@ -388,6 +389,7 @@ class DGraphClient
                 simulates_intent: [uid]
                 core.attribute.completes: default
                 core.attribute.order: default
+                core.attribute.repeating: default
                 ei_type: string
                 followed_by: uid
                 has_condition: [uid]

--- a/tests/Feature/NextIntentDetectionTest.php
+++ b/tests/Feature/NextIntentDetectionTest.php
@@ -3,14 +3,19 @@
 namespace OpenDialogAi\Core\Tests\Feature;
 
 use Exception;
+use GuzzleHttp\Exception\GuzzleException;
 use Mockery\MockInterface;
+use OpenDialogAi\ContextEngine\Contexts\User\CurrentIntentNotSetException;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\ConversationEngine\ConversationEngine;
+use OpenDialogAi\ConversationEngine\ConversationStore\EIModelCreatorException;
 use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Controllers\OpenDialogController;
 use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Graph\Node\NodeDoesNotExistException;
 use OpenDialogAi\Core\Tests\TestCase;
 use OpenDialogAi\Core\Tests\Utils\UtteranceGenerator;
+use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\ResponseEngine\MessageTemplate;
 use OpenDialogAi\ResponseEngine\OutgoingIntent;
 
@@ -263,7 +268,6 @@ EOT;
         $this->assertEquals('my_conversation', $conversationContext->getAttributeValue('current_conversation'));
         $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
         $this->assertEquals('intent.app.response', $conversationContext->getAttributeValue('next_intents')[0]);
-
     }
 
     public function testConversationWithManyIntentsWithSameIdAndIncomingConditions()
@@ -308,6 +312,24 @@ EOT;
         $this->assertEquals('rock_paper_scissors', $conversationContext->getAttributeValue('current_conversation'));
         $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
         $this->assertEquals('intent.app.you_lost', $conversationContext->getAttributeValue('next_intents')[0]);
+    }
+
+    public function testConversationWithRepeatingIntent()
+    {
+        $openDialogController = resolve(OpenDialogController::class);
+
+        $this->createConversationWithRepeatingIntent();
+
+        $this->assertionsForRepeatingConversation($openDialogController);
+    }
+
+    public function testConversationWithRepeatingIntentCrossScene()
+    {
+        $openDialogController = resolve(OpenDialogController::class);
+
+        $this->createConversationWithRepeatingIntentCrossScene();
+
+        $this->assertionsForRepeatingConversation($openDialogController);
     }
 
     public function testConversationWithIncomingConditions()
@@ -543,5 +565,41 @@ conversation:
                         attribute1: user.user_name
             completes: true
 EOT;
+    }
+
+    /**
+     * @param OpenDialogController $openDialogController
+     * @throws GuzzleException
+     * @throws CurrentIntentNotSetException
+     * @throws EIModelCreatorException
+     * @throws NodeDoesNotExistException
+     * @throws FieldNotSupported
+     */
+    private function assertionsForRepeatingConversation(OpenDialogController $openDialogController): void
+    {
+        $this->activateConversation($this->noMatchConversation());
+
+        $conversationContext = ContextService::getConversationContext();
+
+        $utterance = UtteranceGenerator::generateChatOpenUtterance('intent.app.welcome');
+        $openDialogController->runConversation($utterance);
+        $this->assertEquals('intent.app.welcome', $conversationContext->getAttributeValue('interpreted_intent'));
+        $this->assertEquals('with_repeating_intent', $conversationContext->getAttributeValue('current_conversation'));
+        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
+        $this->assertEquals('intent.app.welcomeResponse', $conversationContext->getAttributeValue('next_intents')[0]);
+
+        for ($i = 0; $i < 3; $i++) {
+            $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('intent.app.question', $utterance->getUser()));
+            $this->assertEquals('intent.app.question', $conversationContext->getAttributeValue('interpreted_intent'), sprintf('Repetition %d', $i + 1));
+            $this->assertEquals('with_repeating_intent', $conversationContext->getAttributeValue('current_conversation'), sprintf('Repetition %d', $i + 1));
+            $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'), sprintf('Repetition %d', $i + 1));
+            $this->assertEquals('intent.app.questionResponse', $conversationContext->getAttributeValue('next_intents')[0], sprintf('Repetition %d', $i + 1));
+        }
+
+        $openDialogController->runConversation(UtteranceGenerator::generateChatOpenUtterance('intent.app.questionStop', $utterance->getUser()));
+        $this->assertEquals('intent.app.questionStop', $conversationContext->getAttributeValue('interpreted_intent'));
+        $this->assertEquals('with_repeating_intent', $conversationContext->getAttributeValue('current_conversation'));
+        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
+        $this->assertEquals('intent.app.endResponse', $conversationContext->getAttributeValue('next_intents')[0]);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,7 @@ use OpenDialogAi\ContextEngine\ContextEngineServiceProvider;
 use OpenDialogAi\ConversationBuilder\Conversation;
 use OpenDialogAi\ConversationBuilder\ConversationBuilderServiceProvider;
 use OpenDialogAi\ConversationEngine\ConversationEngineServiceProvider;
+use OpenDialogAi\ConversationEngine\ConversationStore\DGraphConversationStore;
 use OpenDialogAi\ConversationLog\ConversationLogServiceProvider;
 use OpenDialogAi\Core\Conversation\Conversation as ConversationNode;
 use OpenDialogAi\Core\CoreServiceProvider;
@@ -362,7 +363,11 @@ EOT;
 
         $this->assertTrue($conversation->activateConversation());
 
-        return $conversation->buildConversation();
+        $dGraphConversationStore = resolve(DGraphConversationStore::class);
+
+        return $dGraphConversationStore->getConversationConverter()->convertConversation(
+            $dGraphConversationStore->getEIModelConversationTemplate($name)
+        );
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -628,6 +628,20 @@ EOT;
         }
     }
 
+    /**
+     * @return ConversationNode
+     */
+    public function createConversationWithRepeatingIntent(): ConversationNode
+    {
+        $conversationMarkup = $this->getMarkupForConversationWithRepeatingIntent();
+
+        try {
+            return $this->activateConversation($conversationMarkup);
+        } catch (Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
     public function getMarkupForConversationWithVirtualIntent(): string
     {
         /** @lang yaml */
@@ -699,6 +713,32 @@ conversation:
               i: intent.app.continue
           - b:
               i: intent.app.testResponse
+              completes: true
+EOT;
+    }
+
+    public function getMarkupForConversationWithRepeatingIntent(): string
+    {
+        /** @lang yaml */
+        return <<<EOT
+conversation:
+  id: with_repeating_intent
+  scenes:
+    opening_scene:
+      intents:
+          - u:
+              i: intent.app.welcome
+          - b:
+              i: intent.app.welcomeResponse
+          - u:
+              i: intent.app.question
+              repeating: true
+          - b:
+              i: intent.app.questionResponse
+          - u:
+              i: intent.app.end
+          - b:
+              i: intent.app.endResponse
               completes: true
 EOT;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -647,6 +647,20 @@ EOT;
         }
     }
 
+    /**
+     * @return ConversationNode
+     */
+    public function createConversationWithRepeatingIntentCrossScene(): ConversationNode
+    {
+        $conversationMarkup = $this->getMarkupForConversationWithRepeatingIntentCrossScene();
+
+        try {
+            return $this->activateConversation($conversationMarkup);
+        } catch (Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
     public function getMarkupForConversationWithVirtualIntent(): string
     {
         /** @lang yaml */
@@ -738,10 +752,47 @@ conversation:
           - u:
               i: intent.app.question
               repeating: true
+          - u:
+              i: intent.app.questionStop
+              scene: stop_scene
           - b:
               i: intent.app.questionResponse
+              completes: true
+    stop_scene:
+      intents:
+          - b:
+              i: intent.app.endResponse
+              completes: true
+EOT;
+    }
+
+    public function getMarkupForConversationWithRepeatingIntentCrossScene(): string
+    {
+        /** @lang yaml */
+        return <<<EOT
+conversation:
+  id: with_repeating_intent
+  scenes:
+    opening_scene:
+      intents:
           - u:
-              i: intent.app.end
+              i: intent.app.welcome
+          - b:
+              i: intent.app.welcomeResponse
+          - u:
+              i: intent.app.question
+              repeating: true
+              scene: next_scene
+          - u:
+              i: intent.app.questionStop
+              scene: stop_scene
+    next_scene:
+      intents:
+          - b:
+              i: intent.app.questionResponse
+              completes: true
+    stop_scene:
+      intents:
           - b:
               i: intent.app.endResponse
               completes: true


### PR DESCRIPTION
This PR adds various methods and properties to enable a conversation designer to specify that an intent is a repeating intent. It is related to work in #289 as this PR is one in a set of PR's that will enable repeating intent functionality.