### PR TITLE
Feature/bubble field not supported exception

### DIFF
--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -9,9 +9,9 @@ use Illuminate\Support\Facades\Log;
 use OpenDialogAi\ActionEngine\Actions\ActionResult;
 use OpenDialogAi\ActionEngine\Exceptions\ActionNotAvailableException;
 use OpenDialogAi\ActionEngine\Service\ActionEngineInterface;
+use OpenDialogAi\ContextEngine\ContextManager\ContextInterface;
 use OpenDialogAi\ContextEngine\Contexts\Intent\IntentContext;
 use OpenDialogAi\ContextEngine\Contexts\User\CurrentIntentNotSetException;
-use OpenDialogAi\ContextEngine\ContextManager\ContextInterface;
 use OpenDialogAi\ContextEngine\Contexts\User\UserContext;
 use OpenDialogAi\ContextEngine\Exceptions\ContextDoesNotExistException;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
@@ -232,9 +232,7 @@ class ConversationEngine implements ConversationEngineInterface
 
         Log::debug(sprintf('There are %s possible next intents.', count($possibleNextIntents)));
 
-        $defaultInterpreter = $this->interpreterService->getDefaultInterpreter()::getName();
-
-        $defaultIntent = $this->interpreterService->interpret($defaultInterpreter, $utterance)[0];
+        $defaultIntent = $this->interpreterService->interpretDefaultInterpreter($utterance)[0];
 
         Log::debug(sprintf('Default intent is %s', $defaultIntent->getId()));
 
@@ -337,9 +335,7 @@ class ConversationEngine implements ConversationEngineInterface
      */
     private function setCurrentConversation(UserContext $userContext, UtteranceInterface $utterance): ?Conversation
     {
-        $defaultInterpreter = $this->interpreterService->getDefaultInterpreter()::getName();
-
-        $defaultIntent = $this->interpreterService->interpret($defaultInterpreter, $utterance)[0];
+        $defaultIntent = $this->interpreterService->interpretDefaultInterpreter($utterance)[0];
 
         Log::debug(sprintf('Default intent is %s', $defaultIntent->getId()));
 

--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -237,7 +237,7 @@ class ConversationEngine implements ConversationEngineInterface
                 ->interpret($utterance)[0];
         } catch (FieldNotSupported $e) {
             Log::warning(sprintf(
-                'Trying to use %s interpreter to interpret an utterance that does is not supported.',
+                'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
                 $this->interpreterService->getDefaultInterpreter()::getName()
             ));
             $defaultIntent = new NoMatchIntent();
@@ -348,7 +348,7 @@ class ConversationEngine implements ConversationEngineInterface
                 ->interpret($utterance)[0];
         } catch (FieldNotSupported $e) {
             Log::warning(sprintf(
-                'Trying to use %s interpreter to interpret an utterance that does is not supported.',
+                'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
                 $this->interpreterService->getDefaultInterpreter()::getName()
             ));
             $defaultIntent = new NoMatchIntent();
@@ -435,7 +435,7 @@ class ConversationEngine implements ConversationEngineInterface
                         ->interpret($utterance);
                 } catch (FieldNotSupported $e) {
                     Log::warning(sprintf(
-                        'Trying to use %s interpreter to interpret an utterance that does is not supported.',
+                        'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
                         $this->interpreterService->getDefaultInterpreter()::getName()
                     ));
                     $intentsFromInterpreter = new NoMatchIntent();
@@ -596,7 +596,7 @@ class ConversationEngine implements ConversationEngineInterface
                         ->interpret($utterance);
                 } catch (FieldNotSupported $e) {
                     Log::warning(sprintf(
-                        'Trying to use %s interpreter to interpret an utterance that does is not supported.',
+                        'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
                         $this->interpreterService->getDefaultInterpreter()::getName()
                     ));
                     $interpretedIntents = new NoMatchIntent();

--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -232,17 +232,10 @@ class ConversationEngine implements ConversationEngineInterface
 
         Log::debug(sprintf('There are %s possible next intents.', count($possibleNextIntents)));
 
-        try {
-            $defaultInterpreter = $this->interpreterService->getDefaultInterpreter()::getName();
+        $defaultInterpreter = $this->interpreterService->getDefaultInterpreter()::getName();
 
-            $defaultIntent = $this->interpreterService->interpret($defaultInterpreter, $utterance)[0];
-        } catch (FieldNotSupported $e) {
-            Log::warning(sprintf(
-                'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
-                $defaultInterpreter
-            ));
-            $defaultIntent = new NoMatchIntent();
-        }
+        $defaultIntent = $this->interpreterService->interpret($defaultInterpreter, $utterance)[0];
+
         Log::debug(sprintf('Default intent is %s', $defaultIntent->getId()));
 
         $matchingIntents = $this->getMatchingIntents($utterance, $possibleNextIntents, $defaultIntent);
@@ -344,18 +337,10 @@ class ConversationEngine implements ConversationEngineInterface
      */
     private function setCurrentConversation(UserContext $userContext, UtteranceInterface $utterance): ?Conversation
     {
-        try {
-            $defaultInterpreter = $this->interpreterService->getDefaultInterpreter()::getName();
+        $defaultInterpreter = $this->interpreterService->getDefaultInterpreter()::getName();
 
-            $defaultIntent = $this->interpreterService
-                ->interpret($defaultInterpreter, $utterance)[0];
-        } catch (FieldNotSupported $e) {
-            Log::warning(sprintf(
-                'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
-                $defaultInterpreter
-            ));
-            $defaultIntent = new NoMatchIntent();
-        }
+        $defaultIntent = $this->interpreterService->interpret($defaultInterpreter, $utterance)[0];
+
         Log::debug(sprintf('Default intent is %s', $defaultIntent->getId()));
 
         $openingIntents = $this->conversationStore->getAllEIModelOpeningIntents();
@@ -432,18 +417,9 @@ class ConversationEngine implements ConversationEngineInterface
         /* @var EIModelIntent $validIntent */
         foreach ($filteredIntents as $validIntent) {
             if ($validIntent->hasInterpreter()) {
-                try {
-                    $interpreter = $validIntent->getInterpreterId();
+                $interpreter = $validIntent->getInterpreterId();
 
-                    $intentsFromInterpreter = $this->interpreterService
-                        ->interpret($interpreter, $utterance);
-                } catch (FieldNotSupported $e) {
-                    Log::warning(sprintf(
-                        'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
-                        $interpreter
-                    ));
-                    $intentsFromInterpreter = new NoMatchIntent();
-                }
+                $intentsFromInterpreter = $this->interpreterService->interpret($interpreter, $utterance);
 
                 // For each intent from the interpreter check to see if it matches the opening intent candidate.
                 foreach ($intentsFromInterpreter as $interpretedIntent) {
@@ -594,18 +570,9 @@ class ConversationEngine implements ConversationEngineInterface
         /* @var Intent $validIntent */
         foreach ($nextIntents as $validIntent) {
             if ($validIntent->hasInterpreter()) {
-                try {
-                    $interpreter = $validIntent->getInterpreter()->getId();
+                $interpreter = $validIntent->getInterpreter()->getId();
 
-                    $interpretedIntents = $this->interpreterService
-                        ->interpret($interpreter, $utterance);
-                } catch (FieldNotSupported $e) {
-                    Log::warning(sprintf(
-                        'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
-                        $interpreter
-                    ));
-                    $interpretedIntents = new NoMatchIntent();
-                }
+                $interpretedIntents = $this->interpreterService->interpret($interpreter, $utterance);
             } else {
                 $interpretedIntents = [$defaultIntent];
             }

--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -307,7 +307,7 @@ class ConversationEngine implements ConversationEngineInterface
 
             /** @var Intent $nextIntent */
             $nextIntent = $matchingIntents->first()->value;
-            Log::debug(sprintf( 'Intent chosen as %s', $nextIntent->getId()));
+            Log::debug(sprintf('Intent chosen as %s', $nextIntent->getId()));
             $userContext->setCurrentIntent($nextIntent);
 
             if ($nextIntent->causesAction()) {

--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -233,12 +233,13 @@ class ConversationEngine implements ConversationEngineInterface
         Log::debug(sprintf('There are %s possible next intents.', count($possibleNextIntents)));
 
         try {
-            $defaultIntent = $this->interpreterService->getDefaultInterpreter()
-                ->interpret($utterance)[0];
+            $defaultInterpreter = $this->interpreterService->getDefaultInterpreter()::getName();
+
+            $defaultIntent = $this->interpreterService->interpret($defaultInterpreter, $utterance)[0];
         } catch (FieldNotSupported $e) {
             Log::warning(sprintf(
                 'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
-                $this->interpreterService->getDefaultInterpreter()::getName()
+                $defaultInterpreter
             ));
             $defaultIntent = new NoMatchIntent();
         }
@@ -344,12 +345,14 @@ class ConversationEngine implements ConversationEngineInterface
     private function setCurrentConversation(UserContext $userContext, UtteranceInterface $utterance): ?Conversation
     {
         try {
-            $defaultIntent = $this->interpreterService->getDefaultInterpreter()
-                ->interpret($utterance)[0];
+            $defaultInterpreter = $this->interpreterService->getDefaultInterpreter()::getName();
+
+            $defaultIntent = $this->interpreterService
+                ->interpret($defaultInterpreter, $utterance)[0];
         } catch (FieldNotSupported $e) {
             Log::warning(sprintf(
                 'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
-                $this->interpreterService->getDefaultInterpreter()::getName()
+                $defaultInterpreter
             ));
             $defaultIntent = new NoMatchIntent();
         }
@@ -430,13 +433,14 @@ class ConversationEngine implements ConversationEngineInterface
         foreach ($filteredIntents as $validIntent) {
             if ($validIntent->hasInterpreter()) {
                 try {
+                    $interpreter = $validIntent->getInterpreterId();
+
                     $intentsFromInterpreter = $this->interpreterService
-                        ->getInterpreter($validIntent->getInterpreterId())
-                        ->interpret($utterance);
+                        ->interpret($interpreter, $utterance);
                 } catch (FieldNotSupported $e) {
                     Log::warning(sprintf(
                         'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
-                        $this->interpreterService->getDefaultInterpreter()::getName()
+                        $interpreter
                     ));
                     $intentsFromInterpreter = new NoMatchIntent();
                 }
@@ -591,13 +595,14 @@ class ConversationEngine implements ConversationEngineInterface
         foreach ($nextIntents as $validIntent) {
             if ($validIntent->hasInterpreter()) {
                 try {
-                    $interpretedIntents = $this->interpreterService->getInterpreter($validIntent->getInterpreter()
-                        ->getId())
-                        ->interpret($utterance);
+                    $interpreter = $validIntent->getInterpreter()->getId();
+
+                    $interpretedIntents = $this->interpreterService
+                        ->interpret($interpreter, $utterance);
                 } catch (FieldNotSupported $e) {
                     Log::warning(sprintf(
                         'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
-                        $this->interpreterService->getDefaultInterpreter()::getName()
+                        $interpreter
                     ));
                     $interpretedIntents = new NoMatchIntent();
                 }

--- a/src/InterpreterEngine/InterpreterInterface.php
+++ b/src/InterpreterEngine/InterpreterInterface.php
@@ -3,6 +3,7 @@
 namespace OpenDialogAi\InterpreterEngine;
 
 use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\UtteranceInterface;
 use OpenDialogAi\InterpreterEngine\Exceptions\InterpreterNameNotSetException;
 
@@ -22,6 +23,7 @@ interface InterpreterInterface
      *
      * @param UtteranceInterface $utterance
      * @return Intent[]
+     * @throws FieldNotSupported
      */
     public function interpret(UtteranceInterface $utterance) : array;
 }

--- a/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUInterpreter.php
+++ b/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUInterpreter.php
@@ -11,7 +11,6 @@ use OpenDialogAi\Core\Attribute\AttributeBag\AttributeBag;
 use OpenDialogAi\Core\Attribute\AttributeInterface;
 use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Conversation\Intent;
-use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\UtteranceInterface;
 use OpenDialogAi\InterpreterEngine\BaseInterpreter;
 use OpenDialogAi\InterpreterEngine\Interpreters\NoMatchIntent;
@@ -33,9 +32,6 @@ abstract class AbstractNLUInterpreter extends BaseInterpreter
             $intent = $this->createOdIntent($clientResponse);
         } catch (AbstractNLURequestFailedException $e) {
             Log::warning(sprintf("%s failed with message: %s", static::$name, $e->getMessage()));
-            $intent = new NoMatchIntent();
-        } catch (FieldNotSupported $e) {
-            Log::warning(sprintf("Trying to use %s to interpret an utterance that does not support text", static::$name));
             $intent = new NoMatchIntent();
         }
 

--- a/src/InterpreterEngine/Interpreters/CallbackInterpreter.php
+++ b/src/InterpreterEngine/Interpreters/CallbackInterpreter.php
@@ -45,22 +45,18 @@ class CallbackInterpreter extends BaseInterpreter
     public function interpret(UtteranceInterface $utterance): array
     {
         $intent = new NoMatchIntent();
-        try {
-            if ($utterance->getCallbackId()) {
-                $intentName = $utterance->getCallbackId();
+        if ($utterance->getCallbackId()) {
+            $intentName = $utterance->getCallbackId();
 
-                if (array_key_exists($intentName, $this->supportedCallbacks)) {
-                    $intentName = $this->supportedCallbacks[$utterance->getCallbackId()];
-                }
-
-                $intent = new Intent($intentName);
-                $intent->setConfidence(1);
-
-                $this->setValue($utterance, $intent);
-                $this->setFormValues($utterance, $intent);
+            if (array_key_exists($intentName, $this->supportedCallbacks)) {
+                $intentName = $this->supportedCallbacks[$utterance->getCallbackId()];
             }
-        } catch (FieldNotSupported $e) {
-            Log::warning(sprintf('Utterance %s does not support callbacks or callback values', $utterance->getType()));
+
+            $intent = new Intent($intentName);
+            $intent->setConfidence(1);
+
+            $this->setValue($utterance, $intent);
+            $this->setFormValues($utterance, $intent);
         }
 
         return [$intent];

--- a/src/InterpreterEngine/Interpreters/QnAInterpreter.php
+++ b/src/InterpreterEngine/Interpreters/QnAInterpreter.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Log;
 use OpenDialogAi\ContextEngine\Facades\AttributeResolver;
 use OpenDialogAi\Core\Conversation\Intent;
-use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\UtteranceInterface;
 use OpenDialogAi\InterpreterEngine\BaseInterpreter;
 use OpenDialogAi\InterpreterEngine\QnA\QnAClient;
@@ -39,9 +38,6 @@ class QnAInterpreter extends BaseInterpreter
             $intent = $this->createOdIntent($qnaResponse);
         } catch (QnARequestFailedException $e) {
             Log::warning(sprintf('QnA interpreter failed at a QnA client level with message %s', $e->getMessage()));
-            $intent = new NoMatchIntent();
-        } catch (FieldNotSupported $e) {
-            Log::warning('Trying to use QnA interpreter to interpret an utterance that does not support text ');
             $intent = new NoMatchIntent();
         }
 

--- a/src/InterpreterEngine/Service/InterpreterService.php
+++ b/src/InterpreterEngine/Service/InterpreterService.php
@@ -36,18 +36,35 @@ class InterpreterService implements InterpreterServiceInterface
         }
 
         try {
-            $intepreterResult = $this->getInterpreter($interpreterName)->interpret($utterance);
+            $interpreterResult = $this->getInterpreter($interpreterName)->interpret($utterance);
         } catch (FieldNotSupported $e) {
             Log::warning(sprintf(
                 'Trying to use %s interpreter to interpret an utterance/field that is not supported.',
                 $interpreterName
             ));
-            $intepreterResult = [new NoMatchIntent()];
+            $interpreterResult = [new NoMatchIntent()];
         }
 
-        $this->putInterpreterResultToCache($interpreterName, $utterance, $intepreterResult);
+        $this->putInterpreterResultToCache($interpreterName, $utterance, $interpreterResult);
 
-        return $intepreterResult;
+        return $interpreterResult;
+    }
+
+    /**
+     * Will return a @see NoMatchIntent if the name of the default interpreter is not set
+     * @inheritDoc
+     */
+    public function interpretDefaultInterpreter(UtteranceInterface $utterance): array
+    {
+        try {
+            $defaultInterpreterName = $this->getDefaultInterpreter()::getName();
+            return $this->interpret($defaultInterpreterName, $utterance);
+        } catch (InterpreterNameNotSetException $e) {
+            Log::warning(
+                'Trying to interpret using the default interpreter, but it\'s name has not been set. Using a no match'
+            );
+            return [new NoMatchIntent()];
+        }
     }
 
     /**

--- a/src/InterpreterEngine/Service/InterpreterServiceInterface.php
+++ b/src/InterpreterEngine/Service/InterpreterServiceInterface.php
@@ -23,6 +23,13 @@ interface InterpreterServiceInterface
     public function interpret(string $interpreterName, UtteranceInterface $utterance) : array;
 
     /**
+     * Runs @see InterpreterServiceInterface::interpret() for the default interpreter
+     * @param UtteranceInterface $utterance
+     * @return Intent[]
+     */
+    public function interpretDefaultInterpreter(UtteranceInterface $utterance) : array;
+
+    /**
      * Return the interpreter cache time if set or the global default cache time
      *
      * @param string $interpreterName Should be in the format interpreter.{namespace}.{name}

--- a/src/InterpreterEngine/tests/LuisInterpreterTest.php
+++ b/src/InterpreterEngine/tests/LuisInterpreterTest.php
@@ -6,6 +6,7 @@ use OpenDialogAi\Core\Attribute\IntAttribute;
 use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Tests\TestCase;
+use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatChatOpenUtterance;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatTextUtterance;
 use OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter\AbstractNLURequestFailedException;
@@ -82,10 +83,11 @@ class LuisInterpreterTest extends TestCase
     public function testInvalidUtterance()
     {
         $interpreter = new LuisInterpreter();
+        $this->expectException(FieldNotSupported::class);
+
         $intents = $interpreter->interpret(new WebchatChatOpenUtterance());
 
         $this->assertCount(1, $intents);
-        $this->assertEquals(NoMatchIntent::NO_MATCH, $intents[0]->getLabel());
     }
 
     public function testMatch()

--- a/src/InterpreterEngine/tests/QnAInterpreterTest.php
+++ b/src/InterpreterEngine/tests/QnAInterpreterTest.php
@@ -5,6 +5,7 @@ namespace InterpreterEngine\tests;
 use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Tests\TestCase;
+use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatChatOpenUtterance;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatTextUtterance;
 use OpenDialogAi\InterpreterEngine\Interpreters\NoMatchIntent;
@@ -66,10 +67,11 @@ class QnAInterpreterTest extends TestCase
     public function testInvalidUtterance()
     {
         $interpreter = new QnAInterpreter();
+        $this->expectException(FieldNotSupported::class);
+
         $intents = $interpreter->interpret(new WebchatChatOpenUtterance());
 
         $this->assertCount(1, $intents);
-        $this->assertEquals(NoMatchIntent::NO_MATCH, $intents[0]->getLabel());
     }
 
     public function testMatch()

--- a/src/InterpreterEngine/tests/RasaInterpreterTest.php
+++ b/src/InterpreterEngine/tests/RasaInterpreterTest.php
@@ -7,6 +7,7 @@ use OpenDialogAi\Core\Attribute\AttributeInterface;
 use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Tests\TestCase;
+use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatChatOpenUtterance;
 use OpenDialogAi\Core\Utterances\Webchat\WebchatTextUtterance;
 use OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter\AbstractNLURequestFailedException;
@@ -84,12 +85,12 @@ class RasaInterpreterTest extends TestCase
     public function testInvalidUtterance()
     {
         $interpreter = new RasaInterpreter();
+        $this->expectException(FieldNotSupported::class);
 
         /** @var Intent[] $intents */
         $intents = $interpreter->interpret(new WebchatChatOpenUtterance());
 
         $this->assertCount(1, $intents);
-        $this->assertEquals(NoMatchIntent::NO_MATCH, $intents[0]->getLabel());
     }
 
     public function testMatch()

--- a/tests/Bot/Interpreters/TestInterpreter.php
+++ b/tests/Bot/Interpreters/TestInterpreter.php
@@ -4,7 +4,6 @@ namespace OpenDialogAi\Core\Tests\Bot\Interpreters;
 
 use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Conversation\Intent;
-use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\UtteranceInterface;
 use OpenDialogAi\InterpreterEngine\BaseInterpreter;
 
@@ -14,18 +13,11 @@ class TestInterpreter extends BaseInterpreter
 
     public function interpret(UtteranceInterface $utterance): array
     {
-        try {
-            $text = $utterance->getText();
-
-            if (strpos($text, 'Hello') !== false) {
-                $intent = Intent::createIntentWithConfidence('intent.test.hello_bot', 1);
-
-                $intent->addAttribute(new StringAttribute('intent_test', 'test'));
-
-                return [$intent];
-            }
-        } catch (FieldNotSupported $e) {
-            //
+        $text = $utterance->getText();
+        if (strpos($text, 'Hello') !== false) {
+            $intent = Intent::createIntentWithConfidence('intent.test.hello_bot', 1);
+            $intent->addAttribute(new StringAttribute('intent_test', 'test'));
+            return [$intent];
         }
 
         return [];

--- a/tests/Bot/Interpreters/TestInterpreterComposite.php
+++ b/tests/Bot/Interpreters/TestInterpreterComposite.php
@@ -6,7 +6,6 @@ use OpenDialogAi\Core\Attribute\ArrayAttribute;
 use OpenDialogAi\Core\Attribute\test\ExampleAbstractAttributeCollection;
 use OpenDialogAi\Core\Attribute\test\ExampleAbstractCompositeAttribute;
 use OpenDialogAi\Core\Conversation\Intent;
-use OpenDialogAi\Core\Utterances\Exceptions\FieldNotSupported;
 use OpenDialogAi\Core\Utterances\UtteranceInterface;
 use OpenDialogAi\InterpreterEngine\BaseInterpreter;
 
@@ -16,27 +15,22 @@ class TestInterpreterComposite extends BaseInterpreter
 
     public function interpret(UtteranceInterface $utterance): array
     {
-        try {
-            $text = $utterance->getText();
+        $text = $utterance->getText();
+        if (strpos($text, 'Hello') !== false) {
+            $intent = Intent::createIntentWithConfidence('intent.test.hello_bot_comp', 1);
 
-            if (strpos($text, 'Hello') !== false) {
-                $intent = Intent::createIntentWithConfidence('intent.test.hello_bot_comp', 1);
-
-                $intent->addAttribute(new ArrayAttribute('array_test', ['ok']));
-                $intent->addAttribute(
-                    new ExampleAbstractCompositeAttribute(
-                        'result_test',
-                        new ExampleAbstractAttributeCollection(
-                            ['id' => 'one', 'value' => 'go'],
-                            ExampleAbstractAttributeCollection::EXAMPLE_TYPE_ARRAY
-                        )
+            $intent->addAttribute(new ArrayAttribute('array_test', ['ok']));
+            $intent->addAttribute(
+                new ExampleAbstractCompositeAttribute(
+                    'result_test',
+                    new ExampleAbstractAttributeCollection(
+                        ['id' => 'one', 'value' => 'go'],
+                        ExampleAbstractAttributeCollection::EXAMPLE_TYPE_ARRAY
                     )
-                );
+                )
+            );
 
-                return [$intent];
-            }
-        } catch (FieldNotSupported $e) {
-            //
+            return [$intent];
         }
 
         return [];


### PR DESCRIPTION
**Description**
We are starting to see pattern/boiler plate where we need to catch FieldNotSupported Exception on most of the interpreter. 

**Solution**
Let the exception bubble up to the caller (ConversationEngine) & handle/log exception there.