### PR TITLE
Bug fix: opening intent conditions did not allow for _intent attributes

### DIFF
--- a/src/Attribute/Composite/AbstractAttributeCollection.php
+++ b/src/Attribute/Composite/AbstractAttributeCollection.php
@@ -88,8 +88,10 @@ abstract class AbstractAttributeCollection implements AttributeCollectionInterfa
         $arrayOfAttributes = Util::decode($input);
         $resultAttributes = [];
 
-        foreach ($arrayOfAttributes as $attribute) {
-            $resultAttributes[] = AttributeResolver::getAttributeFor($attribute['id'], $attribute['value']);
+        if (!is_null($input)) {
+            foreach ($arrayOfAttributes as $attribute) {
+                $resultAttributes[] = AttributeResolver::getAttributeFor($attribute['id'], $attribute['value']);
+            }
         }
 
         return $resultAttributes;

--- a/src/Attribute/Composite/AbstractAttributeCollection.php
+++ b/src/Attribute/Composite/AbstractAttributeCollection.php
@@ -51,7 +51,7 @@ abstract class AbstractAttributeCollection implements AttributeCollectionInterfa
     /**
      * @inheritDoc
      */
-    public function getAttributes(): array
+    public function getAttributes(): ?array
     {
         return $this->attributes;
     }
@@ -63,8 +63,12 @@ abstract class AbstractAttributeCollection implements AttributeCollectionInterfa
     {
         $serializedResult = [];
 
-        foreach ($this->attributes as $attribute) {
-            $serializedResult[] = ['id' => $attribute->getId(), 'value' => $attribute->getValue()];
+        if (!is_null($this->attributes)) {
+            foreach ($this->attributes as $attribute) {
+                $serializedResult[] = ['id' => $attribute->getId(), 'value' => $attribute->getValue()];
+            }
+        } else {
+            $serializedResult = null;
         }
 
         return Util::encode($serializedResult);
@@ -81,17 +85,19 @@ abstract class AbstractAttributeCollection implements AttributeCollectionInterfa
      * ]
      *
      * @param string $input A JSON Serialisation of attributes
-     * @return AttributeInterface[]
+     * @return AttributeInterface[]|null
      */
-    private function jsonDeserialize($input) : array
+    private function jsonDeserialize($input) : ?array
     {
-        $arrayOfAttributes = Util::decode($input);
-        $resultAttributes = [];
-
         if (!is_null($input)) {
+            $arrayOfAttributes = Util::decode($input);
+            $resultAttributes = [];
+
             foreach ($arrayOfAttributes as $attribute) {
                 $resultAttributes[] = AttributeResolver::getAttributeFor($attribute['id'], $attribute['value']);
             }
+        } else {
+            $resultAttributes = null;
         }
 
         return $resultAttributes;

--- a/src/Attribute/Composite/AttributeCollectionInterface.php
+++ b/src/Attribute/Composite/AttributeCollectionInterface.php
@@ -33,5 +33,5 @@ interface AttributeCollectionInterface extends \JsonSerializable
      *
      * @return AttributeInterface[]
      */
-    public function getAttributes() : array;
+    public function getAttributes() : ?array;
 }

--- a/tests/Feature/NextIntentDetectionTest.php
+++ b/tests/Feature/NextIntentDetectionTest.php
@@ -328,10 +328,6 @@ conversation:
   scenes:
     opening_scene:
       intents:
-        - u: 
-            i: intent.app.hello
-        - b:
-            i: intent.app.response
         - u:
             i: intent.app.make_choice
             expected_attributes:
@@ -366,14 +362,7 @@ EOT;
 
         $conversationContext = ContextService::getConversationContext();
 
-        $utterance = UtteranceGenerator::generateChatOpenUtterance('intent.app.hello');
-        $openDialogController->runConversation($utterance);
-        $this->assertEquals('intent.app.hello', $conversationContext->getAttributeValue('interpreted_intent'));
-        $this->assertEquals('my_conversation', $conversationContext->getAttributeValue('current_conversation'));
-        $this->assertEquals('opening_scene', $conversationContext->getAttributeValue('current_scene'));
-        $this->assertEquals('intent.app.response', $conversationContext->getAttributeValue('next_intents')[0]);
-
-        $utterance = UtteranceGenerator::generateButtonResponseUtterance('make_choice', 'choice.left', $utterance->getUser());
+        $utterance = UtteranceGenerator::generateButtonResponseUtterance('make_choice', 'choice.left');
         $openDialogController->runConversation($utterance);
         $this->assertEquals('intent.app.make_choice', $conversationContext->getAttributeValue('interpreted_intent'));
         $this->assertEquals('my_conversation', $conversationContext->getAttributeValue('current_conversation'));


### PR DESCRIPTION
This PR fixes a bug which meant that opening intent conditions that used the `_intent` context did not work. Due to the `_intent` context's refreshing behaviour (where all its attributes are removed), the AttributeCollection has been updated to allow for removal.