### PR TITLE
Easier action mocking

### DIFF
--- a/src/ActionEngine/ActionEngineServiceProvider.php
+++ b/src/ActionEngine/ActionEngineServiceProvider.php
@@ -21,7 +21,7 @@ class ActionEngineServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__ . '/config/opendialog-actionengine.php', 'opendialog.action_engine');
 
-        $this->app->bind(ActionEngineInterface::class, function () {
+        $this->app->singleton(ActionEngineInterface::class, function () {
             $actionEngineService = new ActionEngine();
             $actionEngineService->setAvailableActions(config('opendialog.action_engine.available_actions'));
 

--- a/src/ActionEngine/Service/ActionEngine.php
+++ b/src/ActionEngine/Service/ActionEngine.php
@@ -36,7 +36,7 @@ class ActionEngine implements ActionEngineInterface
 
                 /** @var ActionInterface $action */
                 $action = new $supportedAction();
-                $this->availableActions[$action->performs()] = $action;
+                $this->registerAction($action);
             } catch (ActionNameNotSetException $exception) {
                 Log::warning(
                     sprintf(
@@ -125,5 +125,16 @@ class ActionEngine implements ActionEngineInterface
             $actionInput->addAttribute($attribute);
         }
         return $actionInput;
+    }
+
+    /**
+     * Registers an action to the engine. This method is useful for mocking actions in tests.
+     *
+     * @param ActionInterface $action
+     * @throws ActionNameNotSetException
+     */
+    public function registerAction(ActionInterface $action): void
+    {
+        $this->availableActions[$action->performs()] = $action;
     }
 }

--- a/src/ActionEngine/Service/ActionEngineInterface.php
+++ b/src/ActionEngine/Service/ActionEngineInterface.php
@@ -3,7 +3,9 @@
 namespace OpenDialogAi\ActionEngine\Service;
 
 use Ds\Map;
+use OpenDialogAi\ActionEngine\Actions\ActionInterface;
 use OpenDialogAi\ActionEngine\Actions\ActionResult;
+use OpenDialogAi\ActionEngine\Exceptions\ActionNameNotSetException;
 use OpenDialogAi\ActionEngine\Exceptions\ActionNotAvailableException;
 
 interface ActionEngineInterface
@@ -33,4 +35,12 @@ interface ActionEngineInterface
      * @throws ActionNotAvailableException
      */
     public function performAction(string $actionName, Map $inputAttributes): ?ActionResult;
+
+    /**
+     * Registers an action to the engine. This method is useful for mocking actions in tests.
+     *
+     * @param ActionInterface $action
+     * @throws ActionNameNotSetException
+     */
+    public function registerAction(ActionInterface $action): void;
 }

--- a/src/ActionEngine/tests/ActionEngineServiceTest.php
+++ b/src/ActionEngine/tests/ActionEngineServiceTest.php
@@ -9,7 +9,6 @@ use OpenDialogAi\ActionEngine\Service\ActionEngineInterface;
 use OpenDialogAi\ActionEngine\Tests\Actions\BrokenAction;
 use OpenDialogAi\ActionEngine\Tests\Actions\DummyAction;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
-use OpenDialogAi\Core\Attribute\IntAttribute;
 use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Tests\TestCase;
 
@@ -150,12 +149,8 @@ class ActionEngineServiceTest extends TestCase
 
     public function testCustomActions()
     {
-        $this->setConfigValue('opendialog.action_engine.custom_actions', [DummyAction::class]);
-
-        /** @var ActionEngineInterface $actionEngine */
-        $actionEngine = app()->make(ActionEngineInterface::class);
-
-        $this->assertContains('actions.core.dummy', array_keys($actionEngine->getAvailableActions()));
+        $this->actionEngine->registerAction(new DummyAction());
+        $this->assertContains('actions.core.dummy', array_keys($this->actionEngine->getAvailableActions()));
     }
 
     protected function setDummyAction(): void


### PR DESCRIPTION
This PR introduces a `registerAction` method to the `ActionEngine` which allows a previously instantiated Action object to be added to the available actions. This is useful as, when creating a partially mocked action with [Mockery](http://docs.mockery.io/en/latest/), we are not able to simply add the generated class name to the `ActionEngine` config file. It seems that doing so causes any expectations to be reset.

This PR also ensures that the `ActionEngine` is a singleton, meaning that we have full control over the registered actions during testing.