### PR TITLE
Adding confidence to AbstractNLUInterpreter logging

### DIFF
--- a/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUInterpreter.php
+++ b/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUInterpreter.php
@@ -50,7 +50,14 @@ abstract class AbstractNLUInterpreter extends BaseInterpreter
         $intent = new NoMatchIntent();
 
         if ($topIntent = $response->getTopScoringIntent()) {
-            Log::debug(sprintf('Creating intent from %s with name %s', static::$name, $topIntent->getLabel()));
+            Log::debug(
+                sprintf(
+                    'Creating intent from %s with name %s and %.2f confidence.',
+                    static::$name,
+                    $topIntent->getLabel(),
+                    $topIntent->getConfidence()
+                )
+            );
             $intent = Intent::createIntentWithConfidence($topIntent->getLabel(), $topIntent->getConfidence());
         }
 


### PR DESCRIPTION
This PR adds the confidence of an interpreted Rasa or LUIS intent to the logged message. This will give us better insight into our NLU interpreters when an intent isn't interpreted as expected - usually it is because the confidence did not meet the desired threshold.