### PR TITLE
Allowing for custom NLU clients

### DIFF
--- a/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUClient.php
+++ b/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUClient.php
@@ -3,59 +3,11 @@
 
 namespace OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Psr7\Response;
-use Illuminate\Support\Facades\Log;
-
-abstract class AbstractNLUClient
+abstract class AbstractNLUClient implements AbstractNLUClientInterface
 {
-    /** @var Client */
-    protected $client;
-
-    /** @var string The app specific URL */
-    protected $appUrl;
-
-    /**
-     * @param Client $client
-     * @param $config
-     */
-    abstract public function __construct(Client $client, $config);
-
-    /**
-     * @param $message
-     * @return mixed
-     * @throws GuzzleException
-     */
-    abstract public function sendRequest($message): Response;
-
     /**
      * @param mixed $response
      * @return AbstractNLUResponse
      */
     abstract public function createResponse($response): AbstractNLUResponse;
-
-    /**
-     * Sends a message to the NLU service and creates a response object
-     * @param $message
-     * @return AbstractNLUResponse
-     * @throws AbstractNLURequestFailedException
-     */
-    public function query($message): AbstractNLUResponse
-    {
-        try {
-            $query = $this->sendRequest($message);
-        } catch (GuzzleException $e) {
-            throw new AbstractNLURequestFailedException($e->getMessage());
-        }
-
-        $responseData = $query->getBody()->getContents();
-        if ($query->getStatusCode() == '200') {
-            Log::debug("Successful client call", ['response' => $responseData]);
-            return $this->createResponse($responseData);
-        } else {
-            Log::warning("Unsuccessful client call", ['response' => $responseData]);
-            throw new AbstractNLURequestFailedException("Client call failed with a non 200 response, please check the logs");
-        }
-    }
 }

--- a/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUClientInterface.php
+++ b/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUClientInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter;
+
+interface AbstractNLUClientInterface
+{
+    /**
+     * @param $message
+     * @return mixed
+     */
+    public function sendRequest($message);
+
+    /**
+     * @param mixed $response
+     * @return AbstractNLUResponse
+     */
+    public function createResponse($response): AbstractNLUResponse;
+
+    /**
+     * Sends a message to the NLU service and creates a response object
+     * @param $message
+     * @return AbstractNLUResponse
+     * @throws AbstractNLURequestFailedException
+     */
+    public function query($message): AbstractNLUResponse;
+}

--- a/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUCustomClient.php
+++ b/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUCustomClient.php
@@ -1,0 +1,41 @@
+<?php
+
+
+namespace OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter;
+
+
+use Exception;
+use Illuminate\Support\Facades\Log;
+
+abstract class AbstractNLUCustomClient extends AbstractNLUClient
+{
+    /**
+     * @param $message
+     * @return AbstractNLUCustomRequest
+     */
+    abstract public function sendRequest($message): AbstractNLUCustomRequest;
+
+    /**
+     * Sends a message to the NLU service and creates a response object
+     * @param $message
+     * @return AbstractNLUResponse
+     * @throws AbstractNLURequestFailedException
+     */
+    public function query($message): AbstractNLUResponse
+    {
+        try {
+            $request = $this->sendRequest($message);
+        } catch (Exception $e) {
+            throw new AbstractNLURequestFailedException($e->getMessage());
+        }
+
+        $responseData = $request->getContents();
+        if ($request->isSuccessful()) {
+            Log::debug("Successful client call", ['response' => $responseData]);
+            return $this->createResponse($responseData);
+        } else {
+            Log::warning("Unsuccessful client call", ['response' => $responseData]);
+            throw new AbstractNLURequestFailedException("Client call failed with a non 200 response, please check the logs");
+        }
+    }
+}

--- a/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUCustomRequest.php
+++ b/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUCustomRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter;
+
+
+abstract class AbstractNLUCustomRequest
+{
+    /**
+     * This method gets the returned contents of the request.
+     *
+     * @return mixed
+     */
+    abstract public function getContents();
+
+    /**
+     * This method returns a boolean representing whether or not the request was successful or not
+     *
+     * @return bool
+     */
+    abstract public function isSuccessful(): bool;
+}

--- a/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUHTTPClient.php
+++ b/src/InterpreterEngine/Interpreters/AbstractNLUInterpreter/AbstractNLUHTTPClient.php
@@ -1,0 +1,55 @@
+<?php
+
+
+namespace OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter;
+
+
+use Exception;
+use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Log;
+use Psr\Http\Message\ResponseInterface;
+
+abstract class AbstractNLUHTTPClient extends AbstractNLUClient
+{
+    /** @var Client */
+    protected $client;
+
+    /** @var string The app specific URL */
+    protected $appUrl;
+
+    /**
+     * @param Client $client
+     * @param $config
+     */
+    abstract public function __construct(Client $client, $config);
+
+    /**
+     * @param $message
+     * @return mixed
+     */
+    abstract public function sendRequest($message): ResponseInterface;
+
+    /**
+     * Sends a message to the NLU service and creates a response object
+     * @param $message
+     * @return AbstractNLUResponse
+     * @throws AbstractNLURequestFailedException
+     */
+    public function query($message): AbstractNLUResponse
+    {
+        try {
+            $query = $this->sendRequest($message);
+        } catch (Exception $e) {
+            throw new AbstractNLURequestFailedException($e->getMessage());
+        }
+
+        $responseData = $query->getBody()->getContents();
+        if ($query->getStatusCode() == '200') {
+            Log::debug("Successful client call", ['response' => $responseData]);
+            return $this->createResponse($responseData);
+        } else {
+            Log::warning("Unsuccessful client call", ['response' => $responseData]);
+            throw new AbstractNLURequestFailedException("Client call failed with a non 200 response, please check the logs");
+        }
+    }
+}

--- a/src/InterpreterEngine/Luis/LuisClient.php
+++ b/src/InterpreterEngine/Luis/LuisClient.php
@@ -3,11 +3,11 @@
 namespace OpenDialogAi\InterpreterEngine\Luis;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
-use OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter\AbstractNLUClient;
+use OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter\AbstractNLUHTTPClient;
 use OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter\AbstractNLUResponse;
+use Psr\Http\Message\ResponseInterface;
 
-class LuisClient extends AbstractNLUClient
+class LuisClient extends AbstractNLUHTTPClient
 {
     /** @var string The app ID */
     private $appId;
@@ -45,7 +45,7 @@ class LuisClient extends AbstractNLUClient
     /**
      * @inheritDoc
      */
-    public function sendRequest($message): Response
+    public function sendRequest($message): ResponseInterface
     {
         return $this->client->request(
             'GET',

--- a/src/InterpreterEngine/Rasa/RasaClient.php
+++ b/src/InterpreterEngine/Rasa/RasaClient.php
@@ -3,11 +3,11 @@
 namespace OpenDialogAi\InterpreterEngine\Rasa;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Response;
-use OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter\AbstractNLUClient;
+use OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter\AbstractNLUHTTPClient;
 use OpenDialogAi\InterpreterEngine\Interpreters\AbstractNLUInterpreter\AbstractNLUResponse;
+use Psr\Http\Message\ResponseInterface;
 
-class RasaClient extends AbstractNLUClient
+class RasaClient extends AbstractNLUHTTPClient
 {
     public function __construct(Client $client, $config)
     {
@@ -18,7 +18,7 @@ class RasaClient extends AbstractNLUClient
     /**
      * @inheritDoc
      */
-    public function sendRequest($message): Response
+    public function sendRequest($message): ResponseInterface
     {
         return $this->client->request(
             'POST',

--- a/src/InterpreterEngine/config/opendialog-interpreterengine-custom.php
+++ b/src/InterpreterEngine/config/opendialog-interpreterengine-custom.php
@@ -2,7 +2,7 @@
 
 return [
     /**
-     * A registration of know LUIS entities mapped to known attribute type. If an entity is returned from LUIS that is
+     * A registration of known LUIS entities mapped to known attribute type. If an entity is returned from LUIS that is
      * not an already registered attribute name and is not mapped here, a StringAttribute will be used
      *
      * Mapping is {luis_entity_type} => {OD_attribute_name}
@@ -12,7 +12,7 @@ return [
     ],
 
     /**
-     * A registration of know RASA entities mapped to known attribute type. If an entity is returned from RASA that is
+     * A registration of known RASA entities mapped to known attribute type. If an entity is returned from RASA that is
      * not an already registered attribute name and is not mapped here, a StringAttribute will be used
      *
      * Mapping is {rasa_entity_type} => {OD_attribute_name}


### PR DESCRIPTION
This PR adds a new `AbstractNLUCustomClient` class that allows for new kinds of `AbstractNLUClient`'s that do not have to rely on making HTTP requests thru Guzzle.