### PR TITLE
Updating message.history_all format

### DIFF
--- a/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
+++ b/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
@@ -53,9 +53,9 @@ class MessageHistoryContext extends AbstractContext
             } else if ($message->type == FormResponseUtterance::TYPE) {
                 $messageText = 'Form submitted.';
             } else if ($message->type == TriggerUtterance::TYPE) {
-                $messageText = '[Trigger message]';
+                $messageText = sprintf('Trigger message (%s)', $message->getCallbackId());
             } else if ($message->type == HandToHumanMessage::TYPE) {
-                $messageText = '[User speaking to human]';
+                $messageText = '(User speaking to human)';
             }
 
             $author = $message->author == "them" ? "Bot" : "User";

--- a/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
+++ b/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
@@ -38,7 +38,7 @@ class MessageHistoryContext extends AbstractContext
         $userId = ContextService::getUserContext()->getUserId();
 
         $messages = Message::where('user_id', $userId)
-            ->orderBy('microtime', 'desc')
+            ->orderBy('microtime', 'asc')
             ->whereNotIn('type', ['chat_open'])
             ->get();
 
@@ -47,6 +47,8 @@ class MessageHistoryContext extends AbstractContext
 
             if ($messageText == '' && isset($message->data['text'])) {
                 $messageText = $message->data['text'];
+            } else if ($message->type == 'form_response') {
+                $messageText = 'Form submitted.';
             }
 
             $author = $message->author == "them" ? "Bot" : "User";

--- a/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
+++ b/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
@@ -49,11 +49,7 @@ class MessageHistoryContext extends AbstractContext
                 $messageText = $message->data['text'];
             }
 
-            $authorNames = [
-                'me' => 'User',
-                'them' => 'Bot'
-            ];
-            $author = $authorNames[$message->author];
+            $author = $message->author == "them" ? "Bot" : "User";
             $messageHistory[] = sprintf('%s: %s<br/>', $author, $messageText);
         }
 

--- a/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
+++ b/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
@@ -53,7 +53,7 @@ class MessageHistoryContext extends AbstractContext
             $messageHistory[] = sprintf('%s: %s<br/>', $author, $messageText);
         }
 
-        $messageHistory = implode("\n", $messageHistory);
+        $messageHistory = urlencode(implode("\n", $messageHistory));
 
         return new StringAttribute('all', $messageHistory);
     }

--- a/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
+++ b/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
@@ -49,7 +49,12 @@ class MessageHistoryContext extends AbstractContext
                 $messageText = $message->data['text'];
             }
 
-            $messageHistory[] = sprintf('%s: %s - %s', $message->author, $messageText, $message->created_at);
+            $authorNames = [
+                'me' => 'User',
+                'them' => 'Bot'
+            ];
+            $author = $authorNames[$message->author];
+            $messageHistory[] = sprintf('%s: %s<br/>', $author, $messageText);
         }
 
         $messageHistory = implode("\n", $messageHistory);

--- a/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
+++ b/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
@@ -7,6 +7,9 @@ use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\ConversationLog\Message;
 use OpenDialogAi\Core\Attribute\AttributeInterface;
 use OpenDialogAi\Core\Attribute\StringAttribute;
+use OpenDialogAi\Core\Utterances\FormResponseUtterance;
+use OpenDialogAi\Core\Utterances\TriggerUtterance;
+use OpenDialogAi\ResponseEngine\Message\HandToHumanMessage;
 
 class MessageHistoryContext extends AbstractContext
 {
@@ -47,8 +50,12 @@ class MessageHistoryContext extends AbstractContext
 
             if ($messageText == '' && isset($message->data['text'])) {
                 $messageText = $message->data['text'];
-            } else if ($message->type == 'form_response') {
+            } else if ($message->type == FormResponseUtterance::TYPE) {
                 $messageText = 'Form submitted.';
+            } else if ($message->type == TriggerUtterance::TYPE) {
+                $messageText = '[Trigger message]';
+            } else if ($message->type == HandToHumanMessage::TYPE) {
+                $messageText = '[User speaking to human]';
             }
 
             $author = $message->author == "them" ? "Bot" : "User";

--- a/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
+++ b/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
@@ -53,7 +53,7 @@ class MessageHistoryContext extends AbstractContext
             } else if ($message->type == FormResponseUtterance::TYPE) {
                 $messageText = 'Form submitted.';
             } else if ($message->type == TriggerUtterance::TYPE) {
-                $messageText = sprintf('Trigger message (%s)', $message->getCallbackId());
+                $messageText = '(Trigger message)';
             } else if ($message->type == HandToHumanMessage::TYPE) {
                 $messageText = '(User speaking to human)';
             }

--- a/src/ContextEngine/tests/MessageHistoryContextTest.php
+++ b/src/ContextEngine/tests/MessageHistoryContextTest.php
@@ -2,10 +2,8 @@
 
 namespace OpenDialogAi\ContextEngine\Tests;
 
-use OpenDialogAi\ContextEngine\Contexts\MessageHistory\MessageHistoryContext;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\ConversationLog\Message;
-use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Tests\TestCase;
 use OpenDialogAi\Core\Tests\Utils\UtteranceGenerator;
 
@@ -31,7 +29,7 @@ class MessageHistoryContextTest extends TestCase
 
         $messageHistoryAttribute = ContextService::getAttributeValue('all', 'message_history');
 
-        $this->assertStringContainsString('me: send message', $messageHistoryAttribute);
-        $this->assertStringContainsString('them: received message', $messageHistoryAttribute);
+        $this->assertStringContainsString(urlencode('User: send message'), $messageHistoryAttribute);
+        $this->assertStringContainsString(urlencode('Bot: received message'), $messageHistoryAttribute);
     }
 }


### PR DESCRIPTION
This PR cleans up the format of the new `message_history.all` attribute. It removes the timestamps and converts author names to more be understandable to an end user.