### PR TITLE
Custom button types

### DIFF
--- a/src/MessageBuilder/Message/Button/CallbackButton.php
+++ b/src/MessageBuilder/Message/Button/CallbackButton.php
@@ -10,25 +10,31 @@ class CallbackButton extends BaseButton
 
     public $callbackId;
 
+    public $type;
+
     /**
      * CallbackButton constructor.
      * @param $text
      * @param $callbackId
      * @param $value
-     * @param $display
+     * @param bool $display
+     * @param string $type
      */
-    public function __construct($text, $callbackId, $value, $display = true)
+    public function __construct($text, $callbackId, $value, $display = true, $type = "")
     {
         $this->text = $text;
         $this->callbackId = $callbackId;
         $this->value = $value;
         $this->display = ($display) ? 'true' : 'false';
+        $this->type = $type;
     }
 
     public function getMarkUp()
     {
+        $typeProperty = $this->type != "" ? " type='$this->type'" : "";
+
         return <<<EOT
-<button>
+<button$typeProperty>
     <text>$this->text</text>
     <value>$this->value</value>
     <callback>$this->callbackId</callback>

--- a/src/MessageBuilder/Message/Button/LinkButton.php
+++ b/src/MessageBuilder/Message/Button/LinkButton.php
@@ -12,25 +12,31 @@ class LinkButton extends BaseButton
 
     public $display;
 
+    public $type;
+
     /**
      * LinkButton constructor.
      * @param $text
      * @param $link
      * @param $linkNewTab
-     * @param $display
+     * @param bool $display
+     * @param string $type
      */
-    public function __construct($text, $link, $linkNewTab, $display = true)
+    public function __construct($text, $link, $linkNewTab, $display = true, $type = "")
     {
         $this->text = $text;
         $this->link = $link;
         $this->linkNewTab = ($linkNewTab) ? 'true' : 'false';
         $this->display = ($display) ? 'true' : 'false';
+        $this->type = $type;
     }
 
     public function getMarkUp()
     {
+        $typeProperty = $this->type != "" ? " type='$this->type'" : "";
+
         return <<<EOT
-<button>
+<button$typeProperty>
     <text>$this->text</text>
     <link new_tab="$this->linkNewTab">$this->link</link>
     <display>$this->display</display>

--- a/src/MessageBuilder/Message/Button/TabSwitchButton.php
+++ b/src/MessageBuilder/Message/Button/TabSwitchButton.php
@@ -8,21 +8,27 @@ class TabSwitchButton extends BaseButton
 
     public $display;
 
+    public $type;
+
     /**
      * TabSwitchButton constructor.
      * @param $text
-     * @param $display
+     * @param bool $display
+     * @param string $type
      */
-    public function __construct($text, $display = true)
+    public function __construct($text, $display = true, $type = "")
     {
         $this->text = $text;
         $this->display = ($display) ? 'true' : 'false';
+        $this->type = $type;
     }
 
     public function getMarkUp()
     {
+        $typeProperty = $this->type != "" ? " type='$this->type'" : "";
+
         return <<<EOT
-<button>
+<button$typeProperty>
     <text>$this->text</text>
     <tab_switch>true</tab_switch>
     <display>$this->display</display>

--- a/src/MessageBuilder/Message/Button/TranscriptDownloadButton.php
+++ b/src/MessageBuilder/Message/Button/TranscriptDownloadButton.php
@@ -8,21 +8,27 @@ class TranscriptDownloadButton extends BaseButton
 
     public $display;
 
+    public $type;
+
     /**
      * TabSwitchButton constructor.
      * @param $text
-     * @param $display
+     * @param bool $display
+     * @param string $type
      */
-    public function __construct($text, $display = true)
+    public function __construct($text, $display = true, $type = "")
     {
         $this->text = $text;
         $this->display = ($display) ? 'true' : 'false';
+        $this->type = $type;
     }
 
     public function getMarkUp()
     {
+        $typeProperty = $this->type != "" ? " type='$this->type'" : "";
+
         return <<<EOT
-<button>
+<button$typeProperty>
     <text>$this->text</text>
     <download>true</download>
     <display>$this->display</display>

--- a/src/ResponseEngine/Formatters/MessageFormatterInterface.php
+++ b/src/ResponseEngine/Formatters/MessageFormatterInterface.php
@@ -79,6 +79,7 @@ interface MessageFormatterInterface
     public const CLEAR_AFTER_INTERACTION = 'clear_after_interaction';
     public const CANCEL_CALLBACK         = 'cancel_callback';
     public const CANCEL_TEXT             = 'cancel_text';
+    public const TYPE                    = 'type';
 
     public function getMessages(string $markup): OpenDialogMessages;
 

--- a/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
+++ b/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
@@ -195,30 +195,34 @@ class WebChatMessageFormatter extends BaseMessageFormatter
         $message->setExternal($template[self::EXTERNAL]);
         foreach ($template[self::BUTTONS] as $button) {
             $display = (isset($button[self::DISPLAY])) ? $button[self::DISPLAY] : true;
+            $type = (isset($button[self::TYPE]) ? $button[self::TYPE] : '');
 
             if (isset($button[self::DOWNLOAD])) {
-                $message->addButton(new TranscriptDownloadButton($button[self::TEXT], $display));
+                $message->addButton(new TranscriptDownloadButton($button[self::TEXT], $display, $type));
             } elseif (isset($button[self::TAB_SWITCH])) {
-                $message->addButton(new TabSwitchButton($button[self::TEXT], $display));
+                $message->addButton(new TabSwitchButton($button[self::TEXT], $display, $type));
             } elseif (isset($button[self::LINK])) {
                 $message->addButton(new LinkButton(
                     $button[self::TEXT],
                     $button[self::LINK],
                     $button[self::LINK_NEW_TAB],
-                    $display
+                    $display,
+                    $type
                 ));
             } elseif (isset($button[self::CLICK_TO_CALL])) {
                 $message->addButton(new ClickToCallButton(
                     $button[self::TEXT],
                     $button[self::CLICK_TO_CALL],
-                    $display
+                    $display,
+                    $type
                 ));
             } else {
                 $message->addButton(new CallbackButton(
                     $button[self::TEXT],
                     $button[self::CALLBACK],
                     $button[self::VALUE],
-                    $display
+                    $display,
+                    $type
                 ));
             }
         }
@@ -587,19 +591,24 @@ class WebChatMessageFormatter extends BaseMessageFormatter
         ];
 
         foreach ($item->button as $button) {
+            $attributes = $button->attributes();
+
             $display = ((string)$button->display) ? $this->convertToBoolean((string)$button->display) : true;
+            $type = $attributes[self::TYPE] ?: "";
 
             if (isset($button->download)) {
                 $template[self::BUTTONS][] = [
                     self::TEXT => trim((string)$button->text),
                     self::DOWNLOAD => true,
                     self::DISPLAY => $display,
+                    self::TYPE => $type,
                 ];
             } elseif (isset($button->tab_switch)) {
                 $template[self::BUTTONS][] = [
                     self::TEXT => trim((string)$button->text),
                     self::TAB_SWITCH => true,
                     self::DISPLAY => $display,
+                    self::TYPE => $type,
                 ];
             } elseif (isset($button->link)) {
                 $buttonLinkNewTab = $this->convertToBoolean((string)$button->link['new_tab']);
@@ -609,12 +618,14 @@ class WebChatMessageFormatter extends BaseMessageFormatter
                     self::LINK => trim((string)$button->link),
                     self::LINK_NEW_TAB => $buttonLinkNewTab,
                     self::DISPLAY => $display,
+                    self::TYPE => $type,
                 ];
             } elseif (isset($button->click_to_call)) {
                 $template[self::BUTTONS][] = [
                     self::TEXT => trim((string)$button->text),
                     self::CLICK_TO_CALL => trim((string)$button->click_to_call),
                     self::DISPLAY => $display,
+                    self::TYPE => $type,
                 ];
             } else {
                 $dom = new DOMDocument();
@@ -656,6 +667,7 @@ class WebChatMessageFormatter extends BaseMessageFormatter
                     self::TEXT => trim($buttonText),
                     self::VALUE => trim((string)$button->value),
                     self::DISPLAY => $display,
+                    self::TYPE => $type,
                 ];
             }
         }

--- a/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
+++ b/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
@@ -417,17 +417,18 @@ class WebChatMessageFormatter extends BaseMessageFormatter
         if (isset($template[self::BUTTONS])) {
             foreach ($template[self::BUTTONS] as $button) {
                 $display = (isset($button[self::DISPLAY])) ? $button[self::DISPLAY] : true;
+                $type = (isset($button[self::TYPE]) ? $button[self::TYPE] : '');
 
                 if (isset($button[self::DOWNLOAD])) {
-                    $message->addButton(new TranscriptDownloadButton($button[self::TEXT], $display));
+                    $message->addButton(new TranscriptDownloadButton($button[self::TEXT], $display, $type));
                 } elseif (isset($button[self::TAB_SWITCH])) {
-                    $message->addButton(new TabSwitchButton($button[self::TEXT], $display));
+                    $message->addButton(new TabSwitchButton($button[self::TEXT], $display, $type));
                 } elseif (isset($button[self::LINK])) {
                     $linkNewTab = $button[self::LINK_NEW_TAB];
-                    $message->addButton(new LinkButton($button[self::TEXT], $button[self::LINK], $linkNewTab, $display));
+                    $message->addButton(new LinkButton($button[self::TEXT], $button[self::LINK], $linkNewTab, $display, $type));
                 } else {
                     $message->addButton(
-                        new CallbackButton($button[self::TEXT], $button[self::CALLBACK], $button[self::VALUE], $display)
+                        new CallbackButton($button[self::TEXT], $button[self::CALLBACK], $button[self::VALUE], $display, $type)
                     );
                 }
             }

--- a/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
+++ b/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
@@ -734,19 +734,24 @@ class WebChatMessageFormatter extends BaseMessageFormatter
         }
 
         foreach ($item->button as $button) {
+            $attributes = $button->attributes();
+
             $display = ((string)$button->display) ? $this->convertToBoolean((string)$button->display) : true;
+            $type = $attributes[self::TYPE] ?: "";
 
             if (isset($button->download)) {
                 $template[self::BUTTONS][] = [
                     self::TEXT => trim((string)$button->text),
                     self::DOWNLOAD => true,
                     self::DISPLAY => $display,
+                    self::TYPE => $type,
                 ];
             } elseif (isset($button->tab_switch)) {
                 $template[self::BUTTONS][] = [
                     self::TEXT => trim((string)$button->text),
                     self::TAB_SWITCH => true,
                     self::DISPLAY => $display,
+                    self::TYPE => $type,
                 ];
             } elseif (isset($button->link)) {
                 $buttonLinkNewTab = $this->convertToBoolean((string)$button->link['new_tab']);
@@ -756,6 +761,7 @@ class WebChatMessageFormatter extends BaseMessageFormatter
                     self::LINK => trim((string)$button->link),
                     self::LINK_NEW_TAB => $buttonLinkNewTab,
                     self::DISPLAY => $display,
+                    self::TYPE => $type,
                 ];
             } else {
                 $template[self::BUTTONS][] = [
@@ -763,6 +769,7 @@ class WebChatMessageFormatter extends BaseMessageFormatter
                     self::CALLBACK => trim((string)$button->callback),
                     self::VALUE => trim((string)$button->value),
                     self::DISPLAY => $display,
+                    self::TYPE => $type,
                 ];
             }
         }

--- a/src/ResponseEngine/Message/Webchat/Button/BaseButton.php
+++ b/src/ResponseEngine/Message/Webchat/Button/BaseButton.php
@@ -8,6 +8,8 @@ abstract class BaseButton
 
     protected $display = true;
 
+    protected $type = "";
+
     /**
      * @param $text
      * @return $this
@@ -44,11 +46,28 @@ abstract class BaseButton
         return $this->display;
     }
 
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType(string $type): void
+    {
+        $this->type = $type;
+    }
+
     public function getData()
     {
         return [
             'text' => $this->getText(),
             'display' => $this->getDisplay(),
+            'type' => $this->getType(),
         ];
     }
 }

--- a/src/ResponseEngine/Message/Webchat/Button/CallbackButton.php
+++ b/src/ResponseEngine/Message/Webchat/Button/CallbackButton.php
@@ -12,14 +12,16 @@ class CallbackButton extends BaseButton
      * @param $text
      * @param $callbackId
      * @param null $value
-     * @param $display
+     * @param bool $display
+     * @param string $type
      */
-    public function __construct($text, $callbackId, $value = null, $display = true)
+    public function __construct($text, $callbackId, $value = null, $display = true, $type = "")
     {
         $this->text = $text;
         $this->callbackId = $callbackId;
         $this->value = $value;
         $this->display = $display;
+        $this->type = $type;
     }
 
     /**

--- a/src/ResponseEngine/Message/Webchat/Button/ClickToCallButton.php
+++ b/src/ResponseEngine/Message/Webchat/Button/ClickToCallButton.php
@@ -9,13 +9,15 @@ class ClickToCallButton extends BaseButton
     /**
      * @param $text
      * @param $phoneNumber
-     * @param $display
+     * @param bool $display
+     * @param string $type
      */
-    public function __construct($text, $phoneNumber, $display = true)
+    public function __construct($text, $phoneNumber, $display = true, $type = "")
     {
         $this->text = $text;
         $this->phoneNumber = $phoneNumber;
         $this->display = $display;
+        $this->type = $type;
     }
 
     /**

--- a/src/ResponseEngine/Message/Webchat/Button/LinkButton.php
+++ b/src/ResponseEngine/Message/Webchat/Button/LinkButton.php
@@ -11,15 +11,17 @@ class LinkButton extends BaseButton
     /**
      * @param $text
      * @param $link
-     * @param $linkNewTab
-     * @param $display
+     * @param bool $linkNewTab
+     * @param bool $display
+     * @param string $type
      */
-    public function __construct($text, $link, $linkNewTab = false, $display = true)
+    public function __construct($text, $link, $linkNewTab = false, $display = true, $type = "")
     {
         $this->text = $text;
         $this->link = $link;
         $this->linkNewTab = $linkNewTab;
         $this->display = $display;
+        $this->type = $type;
     }
 
     /**

--- a/src/ResponseEngine/Message/Webchat/Button/TabSwitchButton.php
+++ b/src/ResponseEngine/Message/Webchat/Button/TabSwitchButton.php
@@ -6,12 +6,14 @@ class TabSwitchButton extends BaseButton
 {
     /**
      * @param $text
-     * @param $display
+     * @param bool $display
+     * @param string $type
      */
-    public function __construct($text, $display = true)
+    public function __construct($text, $display = true, $type = "")
     {
         $this->text = $text;
         $this->display = $display;
+        $this->type = $type;
     }
 
     public function getData()

--- a/src/ResponseEngine/Message/Webchat/Button/TranscriptDownloadButton.php
+++ b/src/ResponseEngine/Message/Webchat/Button/TranscriptDownloadButton.php
@@ -6,12 +6,14 @@ class TranscriptDownloadButton extends BaseButton
 {
     /**
      * @param $text
-     * @param $display
+     * @param bool $display
+     * @param string $type
      */
-    public function __construct($text, $display = true)
+    public function __construct($text, $display = true, $type = "")
     {
         $this->text = $text;
         $this->display = $display;
+        $this->type = $type;
     }
 
     public function getData()

--- a/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
+++ b/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
@@ -152,7 +152,7 @@ EOT;
     public function testButtonMessage()
     {
         // phpcs:ignore
-        $markup = '<message disable_text="1"><button-message clear_after_interaction="1"><text>test</text><button><text>Yes</text><callback>callback_yes</callback><value>true</value></button><button><text>No</text><callback>callback_no</callback><value>false</value></button><button><text>Hidden</text><callback>hidden</callback><display>false</display></button></button-message></message>';
+        $markup = '<message disable_text="1"><button-message clear_after_interaction="1"><text>test</text><button type="yes-button"><text>Yes</text><callback>callback_yes</callback><value>true</value></button><button type="no-button"><text>No</text><callback>callback_no</callback><value>false</value></button><button><text>Hidden</text><callback>hidden</callback><display>false</display></button></button-message></message>';
         $formatter = new WebChatMessageFormatter();
 
         /** @var OpenDialogMessage[] $messages */
@@ -165,18 +165,21 @@ EOT;
                 'callback_id' => 'callback_yes',
                 'value' => 'true',
                 'display' => true,
+                'type' => 'yes-button',
             ],
             [
                 'text' => 'No',
                 'callback_id' => 'callback_no',
                 'value' => 'false',
                 'display' => true,
+                'type' => 'no-button',
             ],
             [
                 'text' => 'Hidden',
                 'callback_id' => 'hidden',
                 'value' => '',
                 'display' => false,
+                'type' => ''
             ],
         ];
 
@@ -242,23 +245,27 @@ EOT;
                 'callback_id' => 'callback_yes',
                 'value' => 'true',
                 'display' => true,
+                'type' => '',
             ],
             [
                 'text' => 'This is a link',
                 'link' => 'https://www.opendialog.ai',
                 'link_new_tab' => true,
                 'display' => true,
+                'type' => '',
             ],
             [
                 'text' => 'No',
                 'callback_id' => 'callback_no',
                 'value' => 'false',
                 'display' => true,
+                'type' => '',
             ],
             [
                 'text' => 'Click to call',
                 'phone_number' => '12312412',
                 'display' => true,
+                'type' => '',
             ],
         ];
 
@@ -300,6 +307,7 @@ EOT;
                 'callback_id' => 'callback_yes',
                 'value' => 'true',
                 'display' => true,
+                'type' => '',
             ],
         ];
 
@@ -342,6 +350,7 @@ EOT;
                 'callback_id' => 'callback_yes',
                 'value' => 'true',
                 'display' => true,
+                'type' => '',
             ],
         ];
 

--- a/src/ResponseEngine/tests/ResponseEngineWebchatMessagesTest.php
+++ b/src/ResponseEngine/tests/ResponseEngineWebchatMessagesTest.php
@@ -183,8 +183,13 @@ class ResponseEngineWebchatMessagesTest extends TestCase
     {
         $message = new WebchatButtonMessage();
         $message->setClearAfterInteraction(false);
-        $button1 = new CallbackButton('Yes', 'callback_yes', true);
+
+        $button1 = new CallbackButton('Yes', 'callback_yes', true, true);
+        $button1->setType('yes-button');
+
         $button2 = new CallbackButton('No', 'callback_no', false);
+        $button2->setType('no-button');
+
         $message->addButton($button1);
         $message->addButton($button2);
         $message->setDisableText(false);
@@ -195,12 +200,14 @@ class ResponseEngineWebchatMessagesTest extends TestCase
                 'callback_id' => 'callback_yes',
                 'value' => true,
                 'display' => true,
+                'type' => 'yes-button',
             ],
             [
                 'text' => 'No',
                 'callback_id' => 'callback_no',
                 'value' => false,
                 'display' => true,
+                'type' => 'no-button',
             ],
         ];
 


### PR DESCRIPTION
This PR allows buttons to have a `type` attribute specified it XML. This value can be picked up by webchat as a CSS class name and therefore allows styling control over buttons.