### PR TITLE
Meta message

### DIFF
--- a/src/MessageBuilder/Message/MetaMessage.php
+++ b/src/MessageBuilder/Message/MetaMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OpenDialogAi\MessageBuilder\Message;
+
+class MetaMessage
+{
+    public $data;
+
+    /**
+     * HandToHumanMessage constructor.
+     * @param $data
+     */
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    public function getMarkUp()
+    {
+        $messageMarkUp = '';
+
+        foreach ($this->data as $key => $value) {
+            $messageMarkUp .= sprintf('<data name="%s">%s</data>', $key, $value);
+        }
+
+        return <<<EOT
+<meta-message>
+    $messageMarkUp
+</meta-message>
+EOT;
+    }
+}

--- a/src/MessageBuilder/MessageMarkUpGenerator.php
+++ b/src/MessageBuilder/MessageMarkUpGenerator.php
@@ -22,6 +22,7 @@ use OpenDialogAi\MessageBuilder\Message\Image\Image;
 use OpenDialogAi\MessageBuilder\Message\ImageMessage;
 use OpenDialogAi\MessageBuilder\Message\ListMessage;
 use OpenDialogAi\MessageBuilder\Message\LongTextMessage;
+use OpenDialogAi\MessageBuilder\Message\MetaMessage;
 use OpenDialogAi\MessageBuilder\Message\RichMessage;
 use OpenDialogAi\MessageBuilder\Message\TextMessage;
 use OpenDialogAi\MessageBuilder\Message\TextMessageWithLink;
@@ -123,6 +124,12 @@ class MessageMarkUpGenerator
     public function addAttributeMessage($text)
     {
         $this->messages[] = new AttributeMessage($text);
+        return $this;
+    }
+
+    public function addMetaMessage($data)
+    {
+        $this->messages[] = new MetaMessage($data);
         return $this;
     }
 

--- a/src/ResponseEngine/Formatters/MessageFormatterInterface.php
+++ b/src/ResponseEngine/Formatters/MessageFormatterInterface.php
@@ -35,6 +35,7 @@ interface MessageFormatterInterface
     public const LONG_TEXT_MESSAGE      = 'long-text-message';
     public const EMPTY_MESSAGE          = 'empty-message';
     public const CTA_MESSAGE            = 'cta-message';
+    public const META_MESSAGE           = 'meta-message';
 
     // PROPERTIES
     public const BUTTONS                 = 'buttons';

--- a/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
+++ b/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
@@ -18,6 +18,7 @@ use OpenDialogAi\ResponseEngine\Message\HandToHumanMessage;
 use OpenDialogAi\ResponseEngine\Message\ImageMessage;
 use OpenDialogAi\ResponseEngine\Message\ListMessage;
 use OpenDialogAi\ResponseEngine\Message\LongTextMessage;
+use OpenDialogAi\ResponseEngine\Message\MetaMessage;
 use OpenDialogAi\ResponseEngine\Message\OpenDialogMessage;
 use OpenDialogAi\ResponseEngine\Message\OpenDialogMessages;
 use OpenDialogAi\ResponseEngine\Message\RichMessage;
@@ -44,6 +45,7 @@ use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatImageMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatListMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatLongTextMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebChatMessages;
+use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatMetaMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatRichMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatTextMessage;
 use OpenDialogAi\ResponseEngine\Service\ResponseEngineService;
@@ -173,6 +175,10 @@ class WebChatMessageFormatter extends BaseMessageFormatter
                 $text = $this->getMessageText($item);
                 $template = [self::TEXT => $text];
                 return $this->generateCtaMessage($template);
+                break;
+            case self::META_MESSAGE:
+                $template = $this->formatMetaTemplate($item);
+                return $this->generateMetaMessage($template);
                 break;
             case self::EMPTY_MESSAGE:
                 return new WebchatEmptyMessage();
@@ -482,6 +488,15 @@ class WebChatMessageFormatter extends BaseMessageFormatter
         return $message;
     }
 
+    /**
+     * @param array $template
+     * @return MetaMessage
+     */
+    public function generateMetaMessage(array $template): MetaMessage
+    {
+        $message = (new WebchatMetaMessage())->setElements($template[self::ELEMENTS]);
+        return $message;
+    }
     /**
      * Resolves the attribute by name to get the value for the attribute message, then resolves any attributes
      * in the resulting text
@@ -866,6 +881,25 @@ class WebChatMessageFormatter extends BaseMessageFormatter
             self::PLACEHOLDER => trim((string)$item->placeholder),
             self::CONFIRMATION_TEXT => trim((string)$item->confirmation_text),
             self::CHARACTER_LIMIT => trim((string)$item->character_limit),
+        ];
+        return $template;
+    }
+
+    /**
+     * Formats the XML item into the required template format
+     *
+     * @param SimpleXMLElement $item
+     * @return array
+     */
+    private function formatMetaTemplate(SimpleXMLElement $item): array
+    {
+        $elements = [];
+        foreach ($item->data as $data) {
+            $elements[(string)$data['name']] = (string)$data;
+        }
+
+        $template = [
+            self::ELEMENTS => $elements,
         ];
         return $template;
     }

--- a/src/ResponseEngine/Message/MetaMessage.php
+++ b/src/ResponseEngine/Message/MetaMessage.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpenDialogAi\ResponseEngine\Message;
+
+interface MetaMessage extends OpenDialogMessage
+{
+    const TYPE = 'meta';
+}

--- a/src/ResponseEngine/Message/Webchat/WebchatMetaMessage.php
+++ b/src/ResponseEngine/Message/Webchat/WebchatMetaMessage.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace OpenDialogAi\ResponseEngine\Message\Webchat;
+
+use OpenDialogAi\ResponseEngine\Message\MetaMessage;
+
+class WebchatMetaMessage extends WebchatMessage implements MetaMessage
+{
+    protected $messageType = self::TYPE;
+
+    private $elements = [];
+
+    /**
+     * @param $submitText
+     * @return $this
+     */
+    public function setElements($elements)
+    {
+        $this->elements = $elements;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getElements()
+    {
+        return $this->elements;
+    }
+
+    /**
+     * @return array
+     */
+    public function getElementsArray()
+    {
+        $elements = [];
+
+        foreach ($this->elements as $key => $element) {
+            $elements[$key] = $element;
+        }
+
+        return $elements;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getData(): ?array
+    {
+        return [
+            'elements' => $this->getElementsArray(),
+            'disable_text' => $this->getDisableText(),
+            'internal' => $this->getInternal(),
+            'hidetime' => $this->getHidetime(),
+            self::TIME => $this->getTime(),
+            self::DATE => $this->getDate()
+        ];
+    }
+}

--- a/src/ResponseEngine/Message/Webchat/WebchatMetaMessage.php
+++ b/src/ResponseEngine/Message/Webchat/WebchatMetaMessage.php
@@ -10,6 +10,13 @@ class WebchatMetaMessage extends WebchatMessage implements MetaMessage
 
     private $elements = [];
 
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->setAsEmpty();
+    }
+
     /**
      * @param $submitText
      * @return $this

--- a/src/ResponseEngine/Rules/MessageXML.php
+++ b/src/ResponseEngine/Rules/MessageXML.php
@@ -196,6 +196,7 @@ class MessageXML extends BaseRule
 
                     case 'empty-message':
                     case 'hand-to-human-message':
+                    case 'meta-message':
                     case 'long-text-message':
                     case 'cta-message':
                         break;

--- a/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
+++ b/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
@@ -1122,4 +1122,18 @@ EOT;
         $this->assertEquals('hi there.', $messages[0]->getText());
         $this->assertEquals(0, $messages[0]->getData()['disable_text']);
     }
+
+    public function testMetaMessage()
+    {
+        $markup = '<message disable_text="1"><meta-message><data name="myData">myValue</data></meta-message></message>';
+        $formatter = new WebChatMessageFormatter();
+
+        /** @var OpenDialogMessage[] $messages */
+        $messages = $formatter->getMessages($markup)->getMessages();
+        $this->assertTrue($messages[0]->isEmpty());
+        $this->assertEquals(1, $messages[0]->getData()['disable_text']);
+
+        $elements = $messages[0]->getElements();
+        $this->assertEquals('myValue', $elements['myData']);
+    }
 }

--- a/tests/Unit/MessageMarkUpGeneratorTest.php
+++ b/tests/Unit/MessageMarkUpGeneratorTest.php
@@ -40,4 +40,16 @@ class MessageMarkUpGeneratorTest extends TestCase
         $this->assertRegexp('/<url>http:\/\/www.example.com<\/url>/', $markUp);
         $this->assertRegexp('/<open-new-tab>true<\/open-new-tab>/', $markUp);
     }
+
+    public function testMetaMarkUpGenerator()
+    {
+        $generator = new MessageMarkUpGenerator();
+        $generator->addMetaMessage([
+            'myName' => 'myValue'
+        ]);
+        $markUp = ($generator->getMarkUp());
+        $this->assertRegexp('/<message disable_text="false" hide_avatar="false">/', $markUp);
+        $this->assertRegexp('/<meta-message>/', $markUp);
+        $this->assertRegexp('/<data name="myName">myValue<\/data>/', $markUp);
+    }
 }


### PR DESCRIPTION
This PR adds a new message called `meta-message`. The message can take multiple `data` elements as follows, that can be picked up by webchat to update the front-end.

```xml
 <meta-message>
    <data name="teamName">Welcome</data> 
  </meta-message>
```