### PR TITLE
Compatibility changes between MySQL and Postgres

### DIFF
--- a/src/ConversationLog/Message.php
+++ b/src/ConversationLog/Message.php
@@ -23,7 +23,7 @@ use Illuminate\Support\Str;
  * @property Carbon|null $updated_at
  * @property string $user
  * @property array $intents
- * @property int microtime
+ * @property string microtime
  * @method static QueryBuilder containingIntent($intent)
  * @method static QueryBuilder containingIntents($intents)
  */

--- a/src/ConversationLog/migrations/2019_04_10_105700_create_messages_table.php
+++ b/src/ConversationLog/migrations/2019_04_10_105700_create_messages_table.php
@@ -21,7 +21,7 @@ class CreateMessagesTable extends Migration
             $table->string('author');
             $table->text('message');
             $table->string('type');
-            $table->binary('data')->nullable(true);
+            $table->text('data')->nullable(true);
             $table->string('message_id')->nullable();
             $table->text('user')->nullable();
 
@@ -29,6 +29,8 @@ class CreateMessagesTable extends Migration
 
             if (DB::connection()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME) == 'sqlite') {
                 $table->timestamp('microtime', 6)->nullable();
+            } elseif (DB::connection()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME) == 'pgsql') {
+                $table->text('microtime', 6)->default(DB::raw('CURRENT_TIMESTAMP(6)'));
             } else {
                 $table->timestamp('microtime', 6)->default(DB::raw('CURRENT_TIMESTAMP(6)'));
             }

--- a/src/ConversationLog/tests/MessageTest.php
+++ b/src/ConversationLog/tests/MessageTest.php
@@ -4,6 +4,7 @@ namespace OpenDialogAi\ConversationLog\tests;
 
 use Illuminate\Support\Str;
 use OpenDialogAi\ConversationLog\Message;
+use OpenDialogAi\ConversationLog\ChatbotUser;
 use OpenDialogAi\Core\Tests\TestCase;
 
 class MessageTest extends TestCase
@@ -31,8 +32,12 @@ class MessageTest extends TestCase
 
     private function createMessage($message, $intents): void
     {
+        $userId = Str::random(20);
+
+        (new ChatbotUser(['user_id' => $userId]))->save();
+
         (new Message([
-            'user_id' => Str::random(20),
+            'user_id' => $userId,
             'author' => 'them',
             'message' => $message,
             'message_id' => Str::random(20),


### PR DESCRIPTION
All tests are passing using both SQLite and PostgreSQL.

The fix is across databases and all the tests pass with both SQLite and PostgreSQL.
In fact, the branch has only the fixes and keeps the initial DB configuration with SQLite.


To use PostgreSQL, instead of SQLite, change the following files:

Add the `postgres` Object to `services` in `.lando.yml` as follows:
```yaml
services:
  postgres:
    type: postgres:12
    portforward: 5432
    creds:
      database: postgres
```

In `tests\TestCase.php`, add the following
```php
// at line 60
$this->artisan('migrate:fresh', [
    '--database' => 'pgsql',
]);
```

and

```php
// at line 96
$app['config']->set('database.default', 'postgres');
$app['config']->set('database.connections.pgsql', [
    'driver' => 'pgsql',
    'host' => env('DB_HOST', 'postgres'),
    'port' => env('DB_PORT', '5432'),
    'database' => 'postgres',
    'username' => 'postgres',
    'password' => '',
    'charset' => 'utf8',
    'prefix' => '',
    'prefix_indexes' => true,
    'schema' => 'public',
    'sslmode' => 'prefer',
]);
```

```shell
lando start
lando test
```