### PR TITLE
Allow u_virtual to work on a completing intent

### DIFF
--- a/tests/Feature/CrossConversationVirtualIntentsTest.php
+++ b/tests/Feature/CrossConversationVirtualIntentsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace OpenDialogAi\Core\Tests\Feature;
+
+use OpenDialogAi\ContextEngine\Facades\ContextService;
+use OpenDialogAi\ConversationEngine\ConversationEngineInterface;
+use OpenDialogAi\Core\Tests\TestCase;
+use OpenDialogAi\Core\Tests\Utils\UtteranceGenerator;
+
+class CrossConversationVirtualIntentsTest extends TestCase
+{
+    /**
+     * @requires DGRAPH
+     */
+    public function testUVirtualBetweenConversations()
+    {
+        $this->activateConversation($this->getStartConversationMarkup());
+        $this->activateConversation($this->getFollowUpConversationMarkUp());
+
+        $user = UtteranceGenerator::generateUser();
+        $startUtterance = UtteranceGenerator::generateChatOpenUtterance('start_1', $user);
+        $userContext = ContextService::createUserContext($startUtterance);
+
+        $conversationEngine = resolve(ConversationEngineInterface::class);
+        $intents = $conversationEngine->getNextIntents($userContext, $startUtterance);
+
+        $this->assertCount(2, $intents);
+        $this->assertEquals('end_1', $intents[0]->getId());
+        $this->assertEquals('continue_b', $intents[1]->getId());
+
+        // Now make sure the second conversation still operates as expected
+        $nextUtterance = UtteranceGenerator::generateChatOpenUtterance('continue_u', $user);
+        $intents = $conversationEngine->getNextIntents($userContext, $nextUtterance);
+        $this->assertCount(1, $intents);
+        $this->assertEquals('end_2', $intents[0]->getId());
+    }
+
+    private function getStartConversationMarkup()
+    {
+        /** @lang yaml */
+        return <<<EOT
+conversation:
+  id: conversation1
+  scenes:
+    opening_scene:
+      intents:
+        - u:
+            i: start_1
+        - b:
+            i: end_1
+            u_virtual:
+              i: start_2
+            completes: true
+EOT;
+    }
+
+    public function getFollowUpConversationMarkUp()
+    {
+        /** @lang yaml */
+        return <<<EOT
+conversation:
+  id: conversation2
+  scenes:
+    opening_scene:
+      intents:
+        - u:
+            i: start_2
+        - b:
+            i: continue_b
+            scene: scene_2
+    scene_2:
+      intents:
+        - u:
+            i: continue_u
+        - b:
+            i: end_2        
+            completes: true
+EOT;
+    }
+}


### PR DESCRIPTION
updates the flow of the conversation engine to update the user's current position after each intent is resolved. This allows an intent with a `u_virtual` directive to complete a conversation and move the user into a new conversation with a matching opening intent