### PR TITLE
returns parent message data

### DIFF
--- a/src/ResponseEngine/Message/Webchat/WebchatAutocompleteMessage.php
+++ b/src/ResponseEngine/Message/Webchat/WebchatAutocompleteMessage.php
@@ -151,7 +151,7 @@ class WebchatAutocompleteMessage extends WebchatMessage implements AutocompleteM
      */
     public function getData(): ?array
     {
-        return [
+        return parent::getData() + [
             'title' => $this->getTitle(),
             'endpoint_url' => $this->getEndpointUrl(),
             'endpoint_params' => $this->getEndpointParams(),


### PR DESCRIPTION
Updates webchat autocomplete message to also return the data array from the parent class so that elements - otherwise it doesn't return elements such as time, date, disable_text, hide_avatar etc 