### PR TITLE
adds placeholder option to autocomplete message

### DIFF
--- a/src/MessageBuilder/Message/AutoCompleteMessage.php
+++ b/src/MessageBuilder/Message/AutoCompleteMessage.php
@@ -16,6 +16,8 @@ class AutoCompleteMessage
 
     public $submitText;
 
+    public $placeholder;
+
     /**
      * AutoCompleteMessage constructor.
      * @param $title
@@ -23,15 +25,17 @@ class AutoCompleteMessage
      * @param $queryParamName
      * @param $callback
      * @param $submitText
+     * @param $placeholder
      * @param array $endpointParams
      */
-    public function __construct($title, $endpointUrl, $queryParamName, $callback, $submitText, $endpointParams = [])
+    public function __construct($title, $endpointUrl, $queryParamName, $callback, $submitText, $placeholder, $endpointParams = [])
     {
         $this->title = $title;
         $this->endpointUrl =$endpointUrl;
         $this->queryParamName= $queryParamName;
         $this->callback = $callback;
         $this->submitText = $submitText;
+        $this->placeholder = $placeholder;
         $this->endpointParams = $endpointParams;
     }
 
@@ -42,6 +46,7 @@ class AutoCompleteMessage
     <title>$this->title</title>
     <callback>$this->callback</callback>
     <submit_text>$this->submitText</submit_text>
+    <placeholder>$this->placeholder</placeholder>
     <options-endpoint>
         <url>$this->endpointUrl</url>
         <params>

--- a/src/MessageBuilder/Message/AutoCompleteMessage.php
+++ b/src/MessageBuilder/Message/AutoCompleteMessage.php
@@ -18,6 +18,8 @@ class AutoCompleteMessage
 
     public $placeholder;
 
+    public $attributeName;
+
     /**
      * AutoCompleteMessage constructor.
      * @param $title
@@ -26,16 +28,26 @@ class AutoCompleteMessage
      * @param $callback
      * @param $submitText
      * @param $placeholder
+     * @param $attributeName
      * @param array $endpointParams
      */
-    public function __construct($title, $endpointUrl, $queryParamName, $callback, $submitText, $placeholder, $endpointParams = [])
-    {
+    public function __construct(
+        $title,
+        $endpointUrl,
+        $queryParamName,
+        $callback,
+        $submitText,
+        $placeholder,
+        $attributeName,
+        $endpointParams = []
+    ) {
         $this->title = $title;
         $this->endpointUrl =$endpointUrl;
         $this->queryParamName= $queryParamName;
         $this->callback = $callback;
         $this->submitText = $submitText;
         $this->placeholder = $placeholder;
+        $this->attributeName = $attributeName;
         $this->endpointParams = $endpointParams;
     }
 
@@ -47,6 +59,7 @@ class AutoCompleteMessage
     <callback>$this->callback</callback>
     <submit_text>$this->submitText</submit_text>
     <placeholder>$this->placeholder</placeholder>
+    <attribute_name>$this->attributeName</attribute_name>
     <options-endpoint>
         <url>$this->endpointUrl</url>
         <params>

--- a/src/MessageBuilder/MessageMarkUpGenerator.php
+++ b/src/MessageBuilder/MessageMarkUpGenerator.php
@@ -403,6 +403,7 @@ class MessageMarkUpGenerator
      * @param $callback
      * @param $submit
      * @param $placeholder
+     * @param $attributeName
      * @param array $endpointParams
      * @return MessageMarkUpGenerator
      */
@@ -413,6 +414,7 @@ class MessageMarkUpGenerator
         $callback,
         $submit,
         $placeholder,
+        $attributeName,
         $endpointParams = []
     ) {
         $this->messages[] = new AutoCompleteMessage(
@@ -422,6 +424,7 @@ class MessageMarkUpGenerator
             $callback,
             $submit,
             $placeholder,
+            $attributeName,
             $endpointParams
         );
         return $this;

--- a/src/MessageBuilder/MessageMarkUpGenerator.php
+++ b/src/MessageBuilder/MessageMarkUpGenerator.php
@@ -317,7 +317,7 @@ class MessageMarkUpGenerator
      */
     public function addFullPageRichMessage($title, $subtitle, $text, $buttons = [], $image = [])
     {
-        $richMessage = new FullPageRichMessage($title, $subtitle, $text, $buttons);
+        $richMessage = new FullPageRichMessage($title, $subtitle, $text);
         foreach ($buttons as $button) {
             $display = (isset($button['display'])) ? $button['display'] : true;
 
@@ -402,17 +402,26 @@ class MessageMarkUpGenerator
      * @param $queryParamName
      * @param $callback
      * @param $submit
+     * @param $placeholder
      * @param array $endpointParams
      * @return MessageMarkUpGenerator
      */
-    public function addAutoCompleteMessage($title, $endpointUrl, $queryParamName, $callback, $submit, $endpointParams = [])
-    {
+    public function addAutoCompleteMessage(
+        $title,
+        $endpointUrl,
+        $queryParamName,
+        $callback,
+        $submit,
+        $placeholder,
+        $endpointParams = []
+    ) {
         $this->messages[] = new AutoCompleteMessage(
             $title,
             $endpointUrl,
             $queryParamName,
             $callback,
             $submit,
+            $placeholder,
             $endpointParams
         );
         return $this;

--- a/src/ResponseEngine/Formatters/MessageFormatterInterface.php
+++ b/src/ResponseEngine/Formatters/MessageFormatterInterface.php
@@ -95,6 +95,7 @@ interface MessageFormatterInterface
     public const YEAR_REQUIRED           = 'year_required';
     public const MAX_DATE                = 'max_date';
     public const MIN_DATE                = 'min_date';
+    public const ATTRIBUTE_NAME          = 'attribute_name';
 
     public function getMessages(string $markup): OpenDialogMessages;
 

--- a/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
+++ b/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
@@ -59,7 +59,7 @@ use SimpleXMLElement;
 /**
  * Webchat Message formatter.
  */
-class WebChatMessageFormatter extends BaseMessageFormatter
+class WebchatMessageFormatter extends BaseMessageFormatter
 {
     /** @var ResponseEngineService */
     private $responseEngineService;
@@ -531,7 +531,8 @@ class WebChatMessageFormatter extends BaseMessageFormatter
             ->setEndpointParams($template[self::ENDPOINT_PARAMS])
             ->setCallback($template[self::CALLBACK])
             ->setSubmitText($template[self::SUBMIT_TEXT])
-            ->setQueryParamName($template[self::QUERY_PARAM_NAME]);
+            ->setQueryParamName($template[self::QUERY_PARAM_NAME])
+            ->setPlaceholder($template[self::PLACEHOLDER]);
         return $message;
     }
 
@@ -998,6 +999,7 @@ class WebChatMessageFormatter extends BaseMessageFormatter
             self::ENDPOINT_URL => (string)$item->{'options-endpoint'}->url,
             self::SUBMIT_TEXT => (string)$item->submit_text,
             self::CALLBACK => (string)$item->callback,
+            self::PLACEHOLDER => (string)$item->placeholder,
             self::ENDPOINT_PARAMS => $endpointParams,
             self::QUERY_PARAM_NAME => (string)$item->{'options-endpoint'}->{'query-param-name'},
         ];

--- a/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
+++ b/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
@@ -532,7 +532,8 @@ class WebchatMessageFormatter extends BaseMessageFormatter
             ->setCallback($template[self::CALLBACK])
             ->setSubmitText($template[self::SUBMIT_TEXT])
             ->setQueryParamName($template[self::QUERY_PARAM_NAME])
-            ->setPlaceholder($template[self::PLACEHOLDER]);
+            ->setPlaceholder($template[self::PLACEHOLDER])
+            ->setAttributeName($template[self::ATTRIBUTE_NAME]);
         return $message;
     }
 
@@ -1000,6 +1001,7 @@ class WebchatMessageFormatter extends BaseMessageFormatter
             self::SUBMIT_TEXT => (string)$item->submit_text,
             self::CALLBACK => (string)$item->callback,
             self::PLACEHOLDER => (string)$item->placeholder,
+            self::ATTRIBUTE_NAME => (string)$item->attribute_name,
             self::ENDPOINT_PARAMS => $endpointParams,
             self::QUERY_PARAM_NAME => (string)$item->{'options-endpoint'}->{'query-param-name'},
         ];

--- a/src/ResponseEngine/Message/Webchat/WebchatAutocompleteMessage.php
+++ b/src/ResponseEngine/Message/Webchat/WebchatAutocompleteMessage.php
@@ -22,6 +22,8 @@ class WebchatAutocompleteMessage extends WebchatMessage implements AutocompleteM
 
     private $placeholder;
 
+    private $attributeName;
+
     /**
      * @param $title
      * @return $this
@@ -167,6 +169,24 @@ class WebchatAutocompleteMessage extends WebchatMessage implements AutocompleteM
     }
 
     /**
+     * @return mixed
+     */
+    public function getAttributeName()
+    {
+        return $this->attributeName;
+    }
+
+    /**
+     * @param mixed $attributeName
+     * @return WebchatAutocompleteMessage
+     */
+    public function setAttributeName($attributeName)
+    {
+        $this->attributeName = $attributeName;
+        return $this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getData(): ?array
@@ -178,7 +198,8 @@ class WebchatAutocompleteMessage extends WebchatMessage implements AutocompleteM
             'query_param_name' => $this->getQueryParamName(),
             'callback' => $this->getCallback(),
             'submit_text' => $this->getSubmitText(),
-            'placeholder' => $this->getPlaceholder()
+            'placeholder' => $this->getPlaceholder(),
+            'attribute_name' => $this->getAttributeName(),
         ];
     }
 }

--- a/src/ResponseEngine/Message/Webchat/WebchatAutocompleteMessage.php
+++ b/src/ResponseEngine/Message/Webchat/WebchatAutocompleteMessage.php
@@ -20,6 +20,8 @@ class WebchatAutocompleteMessage extends WebchatMessage implements AutocompleteM
 
     private $submitText;
 
+    private $placeholder;
+
     /**
      * @param $title
      * @return $this
@@ -147,6 +149,24 @@ class WebchatAutocompleteMessage extends WebchatMessage implements AutocompleteM
     }
 
     /**
+     * @return mixed
+     */
+    public function getPlaceholder()
+    {
+        return $this->placeholder;
+    }
+
+    /**
+     * @param mixed $placeholder
+     * @return WebchatAutocompleteMessage
+     */
+    public function setPlaceholder($placeholder)
+    {
+        $this->placeholder = $placeholder;
+        return $this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getData(): ?array
@@ -158,6 +178,7 @@ class WebchatAutocompleteMessage extends WebchatMessage implements AutocompleteM
             'query_param_name' => $this->getQueryParamName(),
             'callback' => $this->getCallback(),
             'submit_text' => $this->getSubmitText(),
+            'placeholder' => $this->getPlaceholder()
         ];
     }
 }

--- a/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
+++ b/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
@@ -1220,7 +1220,7 @@ EOT;
 
     public function testAutocompleteMessage()
     {
-        /** @lang X<L */
+        /** @lang XML */
         $markup = <<<EOT
 <message disable_text="1">
     <autocomplete-message>
@@ -1228,6 +1228,7 @@ EOT;
         <submit_text>Submit</submit_text>
         <callback>Callback</callback>
         <placeholder>placeholder...</placeholder>
+        <attribute_name>Product</attribute_name>
         <options-endpoint>
             <url>/api/to-hit</url>
             <params>
@@ -1247,6 +1248,7 @@ EOT;
         $this->assertEquals('/api/to-hit', $messages[0]->getData()['endpoint_url']);
         $this->assertEquals('name', $messages[0]->getData()['query_param_name']);
         $this->assertEquals('placeholder...', $messages[0]->getData()['placeholder']);
+        $this->assertEquals('Product', $messages[0]->getData()['attribute_name']);
 
         $endpointParams = $messages[0]->getData()['endpoint_params'];
         $this->assertEquals('country', $endpointParams[0]['name']);

--- a/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
+++ b/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
@@ -1227,6 +1227,7 @@ EOT;
         <title>Title</title>
         <submit_text>Submit</submit_text>
         <callback>Callback</callback>
+        <placeholder>placeholder...</placeholder>
         <options-endpoint>
             <url>/api/to-hit</url>
             <params>
@@ -1245,6 +1246,7 @@ EOT;
         $this->assertEquals('Title', $messages[0]->getData()['title']);
         $this->assertEquals('/api/to-hit', $messages[0]->getData()['endpoint_url']);
         $this->assertEquals('name', $messages[0]->getData()['query_param_name']);
+        $this->assertEquals('placeholder...', $messages[0]->getData()['placeholder']);
 
         $endpointParams = $messages[0]->getData()['endpoint_params'];
         $this->assertEquals('country', $endpointParams[0]['name']);

--- a/tests/Unit/MessageMarkUpGeneratorTest.php
+++ b/tests/Unit/MessageMarkUpGeneratorTest.php
@@ -75,12 +75,15 @@ class MessageMarkUpGeneratorTest extends TestCase
             'callback',
             'Submit',
             'placeholder...',
+            'Product',
             $endpointParams);
         $markUp = $generator->getMarkUp();
         $this->assertRegexp('/<message disable_text="false" hide_avatar="false">/', $markUp);
         $this->assertRegexp('/<autocomplete-message>/', $markUp);
         $this->assertRegexp('/This is the title/', $markUp);
         $this->assertRegexp('/<url>\/api\/v3\/endpoint-url<\/url>/', $markUp);
+        $this->assertRegexp('/<attribute_name>Product<\/attribute_name>/', $markUp);
+
     }
 
     public function testDatePickerUpGenerator()

--- a/tests/Unit/MessageMarkUpGeneratorTest.php
+++ b/tests/Unit/MessageMarkUpGeneratorTest.php
@@ -74,6 +74,7 @@ class MessageMarkUpGeneratorTest extends TestCase
             'query',
             'callback',
             'Submit',
+            'placeholder...',
             $endpointParams);
         $markUp = $generator->getMarkUp();
         $this->assertRegexp('/<message disable_text="false" hide_avatar="false">/', $markUp);


### PR DESCRIPTION
**NB - this PR branches from feature/date-picker-message**

The PR updates the autocomplete message to handle a placeholder text option. This is intended to be used as a placeholder in the input box of the message before a user enters any text

PR updated to include a new field `attribute_name` this defines the name of the attribute that the front end should send back with the value that the user enters