### PR TITLE
allows button messages to not have text set. In this instance, only the buttons should be drawn

### DIFF
--- a/src/ResponseEngine/Rules/MessageXML.php
+++ b/src/ResponseEngine/Rules/MessageXML.php
@@ -58,10 +58,6 @@ class MessageXML extends BaseRule
                         break;
 
                     case 'button-message':
-                        if (empty((string)$item->text)) {
-                            $this->setErrorMessage('Button messages must have "text"');
-                            return false;
-                        }
                         foreach ($item->button as $button) {
                             $buttonXml = $button->text->asXml();
                             // Remove button text enclosing tags.


### PR DESCRIPTION
Updates validation on button messages to allow them to be created without any text