### PR TITLE
returns the correct format for date picker required fields

### DIFF
--- a/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
+++ b/src/ResponseEngine/Formatters/Webchat/WebchatMessageFormatter.php
@@ -1021,9 +1021,9 @@ class WebchatMessageFormatter extends BaseMessageFormatter
             self::CALLBACK => trim((string)$item->callback),
             self::MIN_DATE => (string)$item->min_date ?? null,
             self::MAX_DATE => (string)$item->max_date ?? null,
-            self::DAY_REQUIRED => (string)$item->day_required ?? true,
-            self::MONTH_REQUIRED => (string)$item->month_required ?? true,
-            self::YEAR_REQUIRED => (string)$item->year_required ?? true,
+            self::DAY_REQUIRED => filter_var($item->day_required, FILTER_VALIDATE_BOOLEAN),
+            self::MONTH_REQUIRED => filter_var($item->month_required, FILTER_VALIDATE_BOOLEAN),
+            self::YEAR_REQUIRED => filter_var($item->year_required, FILTER_VALIDATE_BOOLEAN),
             self::ATTRIBUTE_NAME => (string)$item->attribute_name ?? true,
         ];
     }

--- a/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
+++ b/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
@@ -1268,7 +1268,7 @@ EOT;
         <callback>Callback</callback>
         <max_date>today</max_date>
         <min_date>20200101</min_date>
-        <year_required>false</year_required>
+        <year_required>true</year_required>
         <month_required>true</month_required>
         <day_required>false</day_required>
         <attribute_name>Attribute</attribute_name>
@@ -1285,9 +1285,9 @@ EOT;
         $this->assertEquals('Callback', $messages[0]->getData()['callback']);
         $this->assertEquals('today', $messages[0]->getData()['max_date']);
         $this->assertEquals('20200101', $messages[0]->getData()['min_date']);
-        $this->assertEquals('false', $messages[0]->getData()['year_required']);
-        $this->assertEquals('true', $messages[0]->getData()['month_required']);
-        $this->assertEquals('false', $messages[0]->getData()['day_required']);
+        $this->assertTrue($messages[0]->getData()['year_required']);
+        $this->assertTrue($messages[0]->getData()['month_required']);
+        $this->assertFalse($messages[0]->getData()['day_required']);
         $this->assertEquals('Attribute', $messages[0]->getData()['attribute_name']);
     }
 }


### PR DESCRIPTION
Makes sure the webchat formatter returns booleans as expected in the webchat front end