### PR TITLE
Hand to System message

### DIFF
--- a/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
+++ b/src/ContextEngine/Contexts/MessageHistory/MessageHistoryContext.php
@@ -9,7 +9,7 @@ use OpenDialogAi\Core\Attribute\AttributeInterface;
 use OpenDialogAi\Core\Attribute\StringAttribute;
 use OpenDialogAi\Core\Utterances\FormResponseUtterance;
 use OpenDialogAi\Core\Utterances\TriggerUtterance;
-use OpenDialogAi\ResponseEngine\Message\HandToHumanMessage;
+use OpenDialogAi\ResponseEngine\Message\HandToSystemMessage;
 
 class MessageHistoryContext extends AbstractContext
 {
@@ -54,8 +54,8 @@ class MessageHistoryContext extends AbstractContext
                 $messageText = 'Form submitted.';
             } else if ($message->type == TriggerUtterance::TYPE) {
                 $messageText = '(Trigger message)';
-            } else if ($message->type == HandToHumanMessage::TYPE) {
-                $messageText = '(User speaking to human)';
+            } else if ($message->type == HandToSystemMessage::TYPE) {
+                $messageText = '(User was handed over to another system)';
             }
 
             $author = $message->author == "them" ? "Bot" : "User";

--- a/src/MessageBuilder/Message/HandToSystemMessage.php
+++ b/src/MessageBuilder/Message/HandToSystemMessage.php
@@ -2,17 +2,21 @@
 
 namespace OpenDialogAi\MessageBuilder\Message;
 
-class HandToHumanMessage
+class HandToSystemMessage
 {
     public $data;
 
+    public $system;
+
     /**
-     * HandToHumanMessage constructor.
+     * HandToSystemMessage constructor.
+     * @param $system
      * @param $data
      */
-    public function __construct($data)
+    public function __construct($system, $data)
     {
         $this->data = $data;
+        $this->system = $system;
     }
 
     public function getMarkUp()
@@ -24,9 +28,9 @@ class HandToHumanMessage
         }
 
         return <<<EOT
-<hand-to-human-message>
+<hand-to-system-message system="$this->system">
     $messageMarkUp
-</hand-to-human-message>
+</hand-to-system-message>
 EOT;
     }
 }

--- a/src/MessageBuilder/MessageMarkUpGenerator.php
+++ b/src/MessageBuilder/MessageMarkUpGenerator.php
@@ -20,7 +20,7 @@ use OpenDialogAi\MessageBuilder\Message\Form\TextElement;
 use OpenDialogAi\MessageBuilder\Message\FormMessage;
 use OpenDialogAi\MessageBuilder\Message\FullPageFormMessage;
 use OpenDialogAi\MessageBuilder\Message\FullPageRichMessage;
-use OpenDialogAi\MessageBuilder\Message\HandToHumanMessage;
+use OpenDialogAi\MessageBuilder\Message\HandToSystemMessage;
 use OpenDialogAi\MessageBuilder\Message\Image\Image;
 use OpenDialogAi\MessageBuilder\Message\ImageMessage;
 use OpenDialogAi\MessageBuilder\Message\ListMessage;
@@ -114,9 +114,9 @@ class MessageMarkUpGenerator
         return $this;
     }
 
-    public function addHandToHumanMessage($data)
+    public function addHandToSystemMessage($system, $data)
     {
-        $this->messages[] = new HandToHumanMessage($data);
+        $this->messages[] = new HandToSystemMessage($system, $data);
         return $this;
     }
 

--- a/src/ResponseEngine/Formatters/MessageFormatterInterface.php
+++ b/src/ResponseEngine/Formatters/MessageFormatterInterface.php
@@ -10,7 +10,7 @@ use OpenDialogAi\ResponseEngine\Message\EmptyMessage;
 use OpenDialogAi\ResponseEngine\Message\FormMessage;
 use OpenDialogAi\ResponseEngine\Message\FullPageFormMessage;
 use OpenDialogAi\ResponseEngine\Message\FullPageRichMessage;
-use OpenDialogAi\ResponseEngine\Message\HandToHumanMessage;
+use OpenDialogAi\ResponseEngine\Message\HandToSystemMessage;
 use OpenDialogAi\ResponseEngine\Message\ImageMessage;
 use OpenDialogAi\ResponseEngine\Message\ListMessage;
 use OpenDialogAi\ResponseEngine\Message\LongTextMessage;
@@ -27,7 +27,7 @@ interface MessageFormatterInterface
     // TYPES
     public const ATTRIBUTE_MESSAGE      = 'attribute-message';
     public const BUTTON_MESSAGE         = 'button-message';
-    public const HAND_TO_HUMAN_MESSAGE  = 'hand-to-human-message';
+    public const HAND_TO_SYSTEM_MESSAGE  = 'hand-to-system-message';
     public const IMAGE_MESSAGE          = 'image-message';
     public const LIST_MESSAGE           = 'list-message';
     public const TEXT_MESSAGE           = 'text-message';
@@ -98,6 +98,7 @@ interface MessageFormatterInterface
     public const ATTRIBUTE_NAME          = 'attribute_name';
     public const MIN                     = 'min';
     public const MAX                     = 'max';
+    public const SYSTEM                  = 'system';
 
     public function getMessages(string $markup): OpenDialogMessages;
 
@@ -125,7 +126,7 @@ interface MessageFormatterInterface
 
     public function generateTextMessage(array $template): OpenDialogMessage;
 
-    public function generateHandToHumanMessage(array $template): HandToHumanMessage;
+    public function generateHandToSystemMessage(array $template): HandToSystemMessage;
 
     public function generateDatePickerMessage(array $template): DatePickerMessage;
 

--- a/src/ResponseEngine/Formatters/Webchat/WebChatMessageFormatter.php
+++ b/src/ResponseEngine/Formatters/Webchat/WebChatMessageFormatter.php
@@ -16,7 +16,7 @@ use OpenDialogAi\ResponseEngine\Message\EmptyMessage;
 use OpenDialogAi\ResponseEngine\Message\FormMessage;
 use OpenDialogAi\ResponseEngine\Message\FullPageFormMessage;
 use OpenDialogAi\ResponseEngine\Message\FullPageRichMessage;
-use OpenDialogAi\ResponseEngine\Message\HandToHumanMessage;
+use OpenDialogAi\ResponseEngine\Message\HandToSystemMessage;
 use OpenDialogAi\ResponseEngine\Message\ImageMessage;
 use OpenDialogAi\ResponseEngine\Message\ListMessage;
 use OpenDialogAi\ResponseEngine\Message\LongTextMessage;
@@ -44,7 +44,7 @@ use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatEmptyMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatFormMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatFullPageFormMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatFullPageRichMessage;
-use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatHandToHumanMessage;
+use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatHandToSystemMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatImageMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatListMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatLongTextMessage;
@@ -171,9 +171,9 @@ class WebChatMessageFormatter extends BaseMessageFormatter
                 $template = $this->formatLongTextTemplate($item);
                 return $this->generateLongTextMessage($template);
                 break;
-            case self::HAND_TO_HUMAN_MESSAGE:
-                $template = $this->formatHandToHumanTemplate($item);
-                return $this->generateHandToHumanMessage($template);
+            case self::HAND_TO_SYSTEM_MESSAGE:
+                $template = $this->formatHandToSystemTemplate($item);
+                return $this->generateHandToSystemMessage($template);
                 break;
             case self::CTA_MESSAGE:
                 $text = $this->getMessageText($item);
@@ -493,11 +493,13 @@ class WebChatMessageFormatter extends BaseMessageFormatter
 
     /**
      * @param array $template
-     * @return HandToHumanMessage
+     * @return HandToSystemMessage
      */
-    public function generateHandToHumanMessage(array $template): HandToHumanMessage
+    public function generateHandToSystemMessage(array $template): HandToSystemMessage
     {
-        $message = (new WebchatHandToHumanMessage())->setElements($template[self::ELEMENTS]);
+        $message = (new WebchatHandToSystemMessage())
+            ->setSystem($template[self::SYSTEM])
+            ->setElements($template[self::ELEMENTS]);
         return $message;
     }
 
@@ -747,14 +749,17 @@ class WebChatMessageFormatter extends BaseMessageFormatter
      * @param SimpleXMLElement $item
      * @return array
      */
-    private function formatHandToHumanTemplate(SimpleXMLElement $item): array
+    private function formatHandToSystemTemplate(SimpleXMLElement $item): array
     {
+        $system = $item->attributes()[self::SYSTEM];
+
         $elements = [];
         foreach ($item->data as $data) {
             $elements[(string)$data['name']] = (string)$data;
         }
 
         $template = [
+            self::SYSTEM => $system,
             self::ELEMENTS => $elements,
         ];
         return $template;

--- a/src/ResponseEngine/Formatters/Webchat/WebChatMessageFormatter.php
+++ b/src/ResponseEngine/Formatters/Webchat/WebChatMessageFormatter.php
@@ -751,7 +751,7 @@ class WebChatMessageFormatter extends BaseMessageFormatter
      */
     private function formatHandToSystemTemplate(SimpleXMLElement $item): array
     {
-        $system = $item->attributes()[self::SYSTEM];
+        $system = (string)$item->attributes()[self::SYSTEM];
 
         $elements = [];
         foreach ($item->data as $data) {

--- a/src/ResponseEngine/Message/HandToHumanMessage.php
+++ b/src/ResponseEngine/Message/HandToHumanMessage.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace OpenDialogAi\ResponseEngine\Message;
-
-interface HandToHumanMessage extends OpenDialogMessage
-{
-    const TYPE = 'hand-to-human';
-}

--- a/src/ResponseEngine/Message/HandToSystemMessage.php
+++ b/src/ResponseEngine/Message/HandToSystemMessage.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpenDialogAi\ResponseEngine\Message;
+
+interface HandToSystemMessage extends OpenDialogMessage
+{
+    const TYPE = 'hand-to-system';
+}

--- a/src/ResponseEngine/Message/Webchat/WebchatHandToSystemMessage.php
+++ b/src/ResponseEngine/Message/Webchat/WebchatHandToSystemMessage.php
@@ -2,16 +2,35 @@
 
 namespace OpenDialogAi\ResponseEngine\Message\Webchat;
 
-use OpenDialogAi\ResponseEngine\Message\HandToHumanMessage;
+use OpenDialogAi\ResponseEngine\Message\HandToSystemMessage;
 
-class WebchatHandToHumanMessage extends WebchatMessage implements HandToHumanMessage
+class WebchatHandToSystemMessage extends WebchatMessage implements HandToSystemMessage
 {
     protected $messageType = self::TYPE;
+
+    private $system;
 
     private $elements = [];
 
     /**
-     * @param $submitText
+     * @return string
+     */
+    public function getSystem()
+    {
+        return $this->system;
+    }
+
+    /**
+     * @param string $system
+     */
+    public function setSystem($system)
+    {
+        $this->system = $system;
+        return $this;
+    }
+
+    /**
+     * @param $elements
      * @return $this
      */
     public function setElements($elements)
@@ -48,6 +67,7 @@ class WebchatHandToHumanMessage extends WebchatMessage implements HandToHumanMes
     public function getData(): ?array
     {
         return [
+            'system' => $this->getSystem(),
             'elements' => $this->getElementsArray(),
             'disable_text' => $this->getDisableText(),
             'internal' => $this->getInternal(),

--- a/src/ResponseEngine/Rules/MessageXML.php
+++ b/src/ResponseEngine/Rules/MessageXML.php
@@ -190,8 +190,14 @@ class MessageXML extends BaseRule
                         }
                         break;
 
+                    case 'hand-to-system-message':
+                        if ((string)$item->attributes()['system'] == '') {
+                            $this->setErrorMessage('Hand to system messages must have a non-empty "system" attribute.');
+                            return false;
+                        }
+                        break;
+
                     case 'empty-message':
-                    case 'hand-to-human-message':
                     case 'meta-message':
                     case 'long-text-message':
                     case 'cta-message':

--- a/src/ResponseEngine/tests/Formatters/DummyFormatter.php
+++ b/src/ResponseEngine/tests/Formatters/DummyFormatter.php
@@ -11,7 +11,7 @@ use OpenDialogAi\ResponseEngine\Message\EmptyMessage;
 use OpenDialogAi\ResponseEngine\Message\FormMessage;
 use OpenDialogAi\ResponseEngine\Message\FullPageFormMessage;
 use OpenDialogAi\ResponseEngine\Message\FullPageRichMessage;
-use OpenDialogAi\ResponseEngine\Message\HandToHumanMessage;
+use OpenDialogAi\ResponseEngine\Message\HandToSystemMessage;
 use OpenDialogAi\ResponseEngine\Message\ImageMessage;
 use OpenDialogAi\ResponseEngine\Message\ListMessage;
 use OpenDialogAi\ResponseEngine\Message\LongTextMessage;
@@ -56,7 +56,7 @@ class DummyFormatter implements MessageFormatterInterface
         //
     }
 
-    public function generateHandToHumanMessage(array $template): HandToHumanMessage
+    public function generateHandToSystemMessage(array $template): HandToSystemMessage
     {
         //
     }

--- a/src/ResponseEngine/tests/Formatters/TestFormatter.php
+++ b/src/ResponseEngine/tests/Formatters/TestFormatter.php
@@ -10,7 +10,7 @@ use OpenDialogAi\ResponseEngine\Message\EmptyMessage;
 use OpenDialogAi\ResponseEngine\Message\FormMessage;
 use OpenDialogAi\ResponseEngine\Message\FullPageFormMessage;
 use OpenDialogAi\ResponseEngine\Message\FullPageRichMessage;
-use OpenDialogAi\ResponseEngine\Message\HandToHumanMessage;
+use OpenDialogAi\ResponseEngine\Message\HandToSystemMessage;
 use OpenDialogAi\ResponseEngine\Message\ImageMessage;
 use OpenDialogAi\ResponseEngine\Message\ListMessage;
 use OpenDialogAi\ResponseEngine\Message\LongTextMessage;
@@ -53,7 +53,7 @@ class TestFormatter extends BaseMessageFormatter
         //
     }
 
-    public function generateHandToHumanMessage(array $template): HandToHumanMessage
+    public function generateHandToSystemMessage(array $template): HandToSystemMessage
     {
         //
     }

--- a/src/ResponseEngine/tests/Formatters/TestFormatter2.php
+++ b/src/ResponseEngine/tests/Formatters/TestFormatter2.php
@@ -10,7 +10,7 @@ use OpenDialogAi\ResponseEngine\Message\EmptyMessage;
 use OpenDialogAi\ResponseEngine\Message\FormMessage;
 use OpenDialogAi\ResponseEngine\Message\FullPageFormMessage;
 use OpenDialogAi\ResponseEngine\Message\FullPageRichMessage;
-use OpenDialogAi\ResponseEngine\Message\HandToHumanMessage;
+use OpenDialogAi\ResponseEngine\Message\HandToSystemMessage;
 use OpenDialogAi\ResponseEngine\Message\ImageMessage;
 use OpenDialogAi\ResponseEngine\Message\ListMessage;
 use OpenDialogAi\ResponseEngine\Message\LongTextMessage;
@@ -53,7 +53,7 @@ class TestFormatter2 extends BaseMessageFormatter
         //
     }
 
-    public function generateHandToHumanMessage(array $template): HandToHumanMessage
+    public function generateHandToSystemMessage(array $template): HandToSystemMessage
     {
         //
     }

--- a/src/ResponseEngine/tests/ResponseEngineTest.php
+++ b/src/ResponseEngine/tests/ResponseEngineTest.php
@@ -22,7 +22,7 @@ use OpenDialogAi\ResponseEngine\Formatters\Webchat\WebChatMessageFormatter;
 use OpenDialogAi\ResponseEngine\Message\OpenDialogMessage;
 use OpenDialogAi\ResponseEngine\Message\OpenDialogMessages;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatButtonMessage;
-use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatHandToHumanMessage;
+use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatHandToSystemMessage;
 use OpenDialogAi\ResponseEngine\Message\Webchat\WebchatImageMessage;
 use OpenDialogAi\ResponseEngine\MessageTemplate;
 use OpenDialogAi\ResponseEngine\NoMatchingMessagesException;
@@ -251,7 +251,7 @@ class ResponseEngineTest extends TestCase
     /**
      * @requires  DGRAPH
      */
-    public function testWebChatHandToHumanMessage()
+    public function testWebChatHandToSystemMessage()
     {
         OutgoingIntent::create(['name' => 'Hello']);
         $intent = OutgoingIntent::where('name', 'Hello')->first();
@@ -262,7 +262,8 @@ class ResponseEngineTest extends TestCase
         ];
 
         $generator = new MessageMarkUpGenerator();
-        $generator->addHandToHumanMessage($data);
+        $system = "my-custom-chat-system";
+        $generator->addHandToSystemMessage($system, $data);
 
         $attributes = ['username' => 'user.name'];
         $parameters = ['value' => 'dummy'];
@@ -285,11 +286,12 @@ class ResponseEngineTest extends TestCase
         $responseEngineService = $this->app->make(ResponseEngineServiceInterface::class);
         $messageWrapper = $responseEngineService->getMessageForIntent('webchat', 'Hello');
 
+        /** @var WebchatHandToSystemMessage $message */
         $message = $messageWrapper->getMessages()[0];
         $elements = $message->getElements();
 
-        $this->assertInstanceOf(WebchatHandToHumanMessage::class, $message);
-
+        $this->assertInstanceOf(WebchatHandToSystemMessage::class, $message);
+        $this->assertEquals($system, $message->getSystem());
         $this->assertEquals($elements['history'], 'test1');
         $this->assertEquals($elements['email'], 'test2');
     }

--- a/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
+++ b/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
@@ -119,8 +119,8 @@ EOT;
 
         /** @var WebchatHandToSystemMessage $message */
         $message = $messages[0];
-        $this->assertEquals($system, $message->getSystem());
-        $this->assertEquals($system, $message->getData()['system']);
+        $this->assertSame($system, $message->getSystem());
+        $this->assertSame($system, $message->getData()['system']);
         $this->assertEquals(1, $message->getData()['disable_text']);
 
         $elements = $message->getElements();


### PR DESCRIPTION
This PR updates the existing `hand-to-human-message` to be `hand-to-system-message` to better reflect that the user can be "handed over" to _any_ other system, not just necessarily a human-operated system. It also introduces a `system` property that will be used to tell the front-end what system the user should be "handed over" to.