### PR TITLE
allows callback values with escaped dots (`\.`)

### DIFF
--- a/src/Attribute/CallbackValueParser.php
+++ b/src/Attribute/CallbackValueParser.php
@@ -17,6 +17,10 @@ abstract class CallbackValueParser
     const ATTRIBUTE_NAME = 'attribute_name';
     const ATTRIBUTE_VALUE = 'attribute_value';
 
+    const DOT = '.';
+    const DOT_REPLACE = '{dot}';
+    const ESCAPE_STRING = "\.";
+
     /**
      * Parses the callback value and returns an array in the format:
      * [
@@ -31,15 +35,17 @@ abstract class CallbackValueParser
      */
     public static function parseCallbackValue($value): array
     {
+        $value = self::replaceEscaped($value);
         $matches = explode('.', $value);
 
         switch (count($matches)) {
             case 1:
                 $attributeName = self::CALLBACK_VALUE;
-                $attributeValue = $value;
+                $attributeValue = self::restoreEscaped($value);
                 break;
             case 2:
-                [$attributeName, $attributeValue] = $matches;
+                $attributeName = $matches[0];
+                $attributeValue = self::restoreEscaped($matches[1]);
                 break;
             default:
                 Log::warning(sprintf('Parsing invalid button value %s', $value));
@@ -52,5 +58,26 @@ abstract class CallbackValueParser
             self::ATTRIBUTE_NAME  => $attributeName,
             self::ATTRIBUTE_VALUE => $attributeValue
         ];
+    }
+
+    /**
+     * Replaces all \. character sequences with {dot} so that it doesn't affect splitting
+     *
+     * @param $value
+     * @return string
+     */
+    private static function replaceEscaped($value)
+    {
+        return str_replace(self::ESCAPE_STRING, self::DOT_REPLACE, $value);
+    }
+
+    /**
+     * Restores the escaped string {dot} with an actual .
+     * @param string $value
+     * @return string
+     */
+    private static function restoreEscaped(string $value)
+    {
+        return str_replace(self::DOT_REPLACE, self::DOT, $value);
     }
 }

--- a/tests/Unit/Attribute/CallbackValueParserTest.php
+++ b/tests/Unit/Attribute/CallbackValueParserTest.php
@@ -25,4 +25,17 @@ class CallbackValueParserTest extends TestCase
         $this->assertEquals("name.value.broken", $parseButtonValue['attribute_value']);
         $this->assertEquals(CallbackValueParser::CALLBACK_VALUE, $parseButtonValue['attribute_name']);
     }
+
+    public function testCallbackValueEscaped()
+    {
+        $buttonValue = "name.value\.escaped";
+        $parseButtonValue = CallbackValueParser::parseCallbackValue($buttonValue);
+        $this->assertEquals("value.escaped", $parseButtonValue['attribute_value']);
+        $this->assertEquals('name', $parseButtonValue['attribute_name']);
+
+        $buttonValue = "name.value\.e\.s\.c\.a\.p\.e\.d";
+        $parseButtonValue = CallbackValueParser::parseCallbackValue($buttonValue);
+        $this->assertEquals("value.e.s.c.a.p.e.d", $parseButtonValue['attribute_value']);
+        $this->assertEquals('name', $parseButtonValue['attribute_name']);
+    }
 }


### PR DESCRIPTION
Seeks to allow incoming attribute values that are parsed by the callback interpreter to use `.` in their values. Any incoming value will first have any escaped `.`s replaced with a temp string before being split so that they are still considered valid. When the attribute name and value have been split, the temp string is replaced with an actual `.` 