### PR TITLE
ensures the microtime will always return decimal values

### DIFF
--- a/src/ConversationLog/Message.php
+++ b/src/ConversationLog/Message.php
@@ -49,6 +49,16 @@ class Message extends Model
     ];
 
     /**
+     * Returns the microtime always formatted to include the trailing decimals, even for an exact hit on a second
+     *
+     * @return string
+     */
+    protected static function getMicrotime()
+    {
+        return number_format(microtime(true), 6, '.', '');
+    }
+
+    /**
      * Deserialize the data field
      *
      * @param $value
@@ -113,7 +123,7 @@ class Message extends Model
 
         // Generate a timestamp if we weren't given one.
         if (empty($microtime)) {
-            $microtime = DateTime::createFromFormat('U.u', microtime(true))->format('Y-m-d H:i:s.u');
+            $microtime = DateTime::createFromFormat('U.u', self::getMicrotime())->format('Y-m-d H:i:s.u');
         }
 
         $message = new self([


### PR DESCRIPTION
We have seen an issue in the Message class where the error `Call to a member function format() on bool` is seen in the logs and the user receives an error in the chatbot.

This fix updates the part of the core where `microtime` is used to make sure that the value is number formatted to include trailing 0s even when it hits an exact second.