### PR TITLE
setIntent added to OpenDialogMessage interface

### DIFF
--- a/src/ResponseEngine/Message/OpenDialogMessage.php
+++ b/src/ResponseEngine/Message/OpenDialogMessage.php
@@ -29,4 +29,12 @@ interface OpenDialogMessage
      * @return bool
      */
     public function isEmpty(): bool;
+
+    /**
+     * Sets the interpreter intent string to the message
+     *
+     * @param string $intent
+     * @return $this
+     */
+    public function setIntent(string $intent): self;
 }

--- a/src/ResponseEngine/Message/Webchat/WebchatMessage.php
+++ b/src/ResponseEngine/Message/Webchat/WebchatMessage.php
@@ -174,7 +174,7 @@ abstract class WebchatMessage implements OpenDialogMessage
      * @param $intent
      * @return $this
      */
-    public function setIntent($intent)
+    public function setIntent(string $intent): OpenDialogMessage
     {
         $this->intent = $intent;
         return $this;

--- a/src/ResponseEngine/Service/ResponseEngineService.php
+++ b/src/ResponseEngine/Service/ResponseEngineService.php
@@ -318,7 +318,7 @@ class ResponseEngineService implements ResponseEngineServiceInterface
 
     /**
      * @param $intentName
-     * @param $messages
+     * @param OpenDialogMessages $messages
      */
     private function setMessagesIntent($intentName, $messages)
     {


### PR DESCRIPTION
moves the `setIntent` method on WebchatMessage up to the OpenDialogMessage interface to enforce it being added to all message types.

This is needed because other packages that implement the interface will no know they need to implement this method