### PR TITLE
Allow button message text element to be empty

### DIFF
--- a/src/ResponseEngine/Message/Webchat/WebchatMessage.php
+++ b/src/ResponseEngine/Message/Webchat/WebchatMessage.php
@@ -47,7 +47,9 @@ abstract class WebchatMessage implements OpenDialogMessage
      */
     public function setText($format, $args = [], bool $noSpecialChars = false)
     {
-        if ($noSpecialChars) {
+        if (is_null($format) || $format == "") {
+            $this->text = null;
+        } elseif ($noSpecialChars) {
             $this->text = vsprintf($format, $args);
         } else {
             // Escape &, <, > characters

--- a/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
+++ b/src/ResponseEngine/tests/ResponseEngineWebchatMessageFormatterTest.php
@@ -200,6 +200,7 @@ EOT;
 
         $this->assertEquals(true, $message->getData()['clear_after_interaction']);
         $this->assertEquals(true, $message->getData()['disable_text']);
+        $this->assertEquals('test', $message->getData()['text']);
         $this->assertEquals($expectedOutput, $message->getButtonsArray());
 
         $markup = <<<EOT
@@ -286,6 +287,30 @@ EOT;
 
         $this->assertEquals(false, $message->getData()['clear_after_interaction']);
         $this->assertEquals(false, $message->getData()['disable_text']);
+        $this->assertEquals('test', $message->getData()['text']);
+        $this->assertEquals($expectedOutput, $message->getButtonsArray());
+
+        // phpcs:ignore
+        $markup = '<message><button-message><text></text><button type="no-button"><text>No</text><callback>callback_no</callback><value>false</value></button></button-message></message>';
+        $formatter = new WebChatMessageFormatter();
+
+        /** @var OpenDialogMessage[] $messages */
+        $messages = $formatter->getMessages($markup)->getMessages();
+        $message = $messages[0];
+
+        $expectedOutput = [
+            [
+                'text' => 'No',
+                'callback_id' => 'callback_no',
+                'value' => 'false',
+                'display' => true,
+                'type' => 'no-button',
+            ],
+        ];
+
+        $this->assertEquals(false, $message->getData()['clear_after_interaction']);
+        $this->assertEquals(false, $message->getData()['disable_text']);
+        $this->assertNull($message->getData()['text']);
         $this->assertEquals($expectedOutput, $message->getButtonsArray());
     }
 


### PR DESCRIPTION
This PR allows for button message text to be `null` which is already accounted for by [Webchat](https://github.com/opendialogai/webchat). This means that you can have buttons without needing preceding text.