### PR TITLE
Null check on DGraph Response

### DIFF
--- a/src/Graph/DGraph/DGraphMutationResponse.php
+++ b/src/Graph/DGraph/DGraphMutationResponse.php
@@ -10,7 +10,7 @@ class DGraphMutationResponse
 
     private $response;
 
-    private $data;
+    private $data = null;
 
     private $errors;
 
@@ -47,7 +47,7 @@ class DGraphMutationResponse
 
     public function isSuccessful()
     {
-        if ($this->getData()['code'] == self::SUCCESS) {
+        if ($this->getData() && $this->getData()['code'] == self::SUCCESS) {
             return true;
         }
 


### PR DESCRIPTION
This PR fixes issue https://github.com/opendialogai/core/issues/420 by first checking if the data element has been set before checking the `code` within it.

It seems like this issue will only affect projects from PHP 7.4 onwards (previously, PHP would return a null in this case which would fail the check as expected in the code flow)

We have seen an uncaught exception thrown from this code in some projects, and in theory, this fix should allow the code to run as expected avoiding the issues we've seen