### PR TITLE
OPNDLG-330 Dynamic Attributes

### DIFF
--- a/database/migrations/2021_01_22_160714_create_dynamic_attributes_table.php
+++ b/database/migrations/2021_01_22_160714_create_dynamic_attributes_table.php
@@ -15,6 +15,7 @@ class CreateDynamicAttributesTable extends Migration
     {
         Schema::create('dynamic_attributes', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->timestamps();
             $table->string('attribute_id')->unique();
             $table->string('attribute_type');
         });

--- a/database/migrations/2021_01_22_160714_create_dynamic_attributes_table.php
+++ b/database/migrations/2021_01_22_160714_create_dynamic_attributes_table.php
@@ -14,9 +14,9 @@ class CreateDynamicAttributesTable extends Migration
     public function up()
     {
         Schema::create('dynamic_attributes', function (Blueprint $table) {
-            $table->string('id')->unique();
-            $table->string('type');
-            $table->primary('id');
+            $table->bigIncrements('id');
+            $table->string('attribute_id')->unique();
+            $table->string('attribute_type');
         });
     }
 

--- a/database/migrations/2021_01_22_160714_create_dynamic_attributes_table.php
+++ b/database/migrations/2021_01_22_160714_create_dynamic_attributes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateDynamicAttributesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('dynamic_attributes', function (Blueprint $table) {
+            $table->string('id')->unique();
+            $table->string('type');
+            $table->primary('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('dynamic_attributes');
+    }
+}

--- a/src/ContextEngine/AttributeResolver/AttributeResolver.php
+++ b/src/ContextEngine/AttributeResolver/AttributeResolver.php
@@ -13,6 +13,8 @@ use OpenDialogAi\Core\Attribute\StringAttribute;
  */
 class AttributeResolver
 {
+    public static $validIdPattern = "/^([a-z]+_)*[a-z]+$/";
+    public static $validTypePattern = "/^attribute\.[A-Za-z]*\.[A-Za-z_]*$/";
     /* @var array */
     private $supportedAttributes = [];
 
@@ -27,6 +29,28 @@ class AttributeResolver
     public function getSupportedAttributes()
     {
         return $this->supportedAttributes;
+    }
+
+    /**
+     * Checks if the id of the DynamicAttribute is in the right format
+     *
+     * @param string $id
+     * @return bool
+     */
+    public static function isValidId(string $id): bool
+    {
+        return preg_match(AttributeResolver::$validIdPattern, $id) === 1;
+    }
+
+    /**
+     * Checks if the type of the DynamicAttribute is in the right format
+     *
+     * @param string $type
+     * @return bool
+     */
+    public static function isValidType(string $type): bool
+    {
+        return preg_match(AttributeResolver::$validTypePattern, $type) === 1;
     }
 
     /**

--- a/src/DynamicAttribute.php
+++ b/src/DynamicAttribute.php
@@ -2,39 +2,13 @@
 
 namespace OpenDialogAi\Core;
 
-use App\Http\Resources\DynamicAttributeCollection;
 use Illuminate\Database\Eloquent\Model;
 
 class DynamicAttribute extends Model
 {
-    static public $validIdPattern = "/^([a-z]+_)*[a-z]+$/";
-    static public $validTypePattern = "/^attribute\.[A-Za-z]*\.[A-Za-z_]*$/";
-
     public $timestamps = false;
 
     protected $table = 'dynamic_attributes';
     protected $fillable = ['attribute_id', 'attribute_type'];
-
-    /**
-     * Checks if the id of the DynamicAttribute is in the right format
-     *
-     * @param string $id
-     * @return bool
-     */
-    public static function isValidId(string $id) : bool
-    {
-        return preg_match(static::$validIdPattern, $id) === 1;
-    }
-
-    /**
-     * Checks if the type of the DynamicAttribute is in the right format
-     *
-     * @param string $type
-     * @return bool
-     */
-    public static function isValidType(string $type) : bool
-    {
-        return preg_match(static::$validTypePattern, $type) === 1;
-    }
 
 }

--- a/src/DynamicAttribute.php
+++ b/src/DynamicAttribute.php
@@ -2,22 +2,18 @@
 
 namespace OpenDialogAi\Core;
 
+use App\Http\Resources\DynamicAttributeCollection;
 use Illuminate\Database\Eloquent\Model;
 
 class DynamicAttribute extends Model
 {
-    static private $validIdPattern = "/^([a-z]+_)*[a-z]+$/";
-    static private $validTypePattern = "/^attribute\.[A-Za-z]*\.[A-Za-z_]*$/";
-
-    public $incrementing = false;
+    static public $validIdPattern = "/^([a-z]+_)*[a-z]+$/";
+    static public $validTypePattern = "/^attribute\.[A-Za-z]*\.[A-Za-z_]*$/";
 
     public $timestamps = false;
 
     protected $table = 'dynamic_attributes';
-    protected $fillable = ['id', 'type'];
-    protected $keyType = 'string';
-    protected $primaryKey = 'id';
-
+    protected $fillable = ['attribute_id', 'attribute_type'];
 
     /**
      * Checks if the id of the DynamicAttribute is in the right format

--- a/src/DynamicAttribute.php
+++ b/src/DynamicAttribute.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace OpenDialogAi\Core;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DynamicAttribute extends Model
+{
+    static private $validIdPattern = "/^([a-z]+_)*[a-z]+$/";
+    static private $validTypePattern = "/^attribute\.[A-Za-z]*\.[A-Za-z_]*$/";
+
+    public $incrementing = false;
+
+    public $timestamps = false;
+
+    protected $table = 'dynamic_attributes';
+    protected $fillable = ['id', 'type'];
+    protected $keyType = 'string';
+    protected $primaryKey = 'id';
+
+
+    /**
+     * Checks if the id of the DynamicAttribute is in the right format
+     *
+     * @param string $id
+     * @return bool
+     */
+    public static function isValidId(string $id) : bool
+    {
+        return preg_match(static::$validIdPattern, $id) === 1;
+    }
+
+    /**
+     * Checks if the type of the DynamicAttribute is in the right format
+     *
+     * @param string $type
+     * @return bool
+     */
+    public static function isValidType(string $type) : bool
+    {
+        return preg_match(static::$validTypePattern, $type) === 1;
+    }
+
+}

--- a/src/DynamicAttribute.php
+++ b/src/DynamicAttribute.php
@@ -6,8 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 
 class DynamicAttribute extends Model
 {
-    public $timestamps = false;
-
     protected $table = 'dynamic_attributes';
     protected $fillable = ['attribute_id', 'attribute_type'];
 


### PR DESCRIPTION
Adds the ability to define attributes dynamically in the database instead of only in config files.

Adds a new Laravel Model 'Dynamic Attribute' which stores an attribute id (unique snake_case string) and attribute type (attribute.core.<name>) in the database. Includes two regex patterns to check the format of the attribute id and type.

Intended for use in conjuction with this PR for opendialog: https://github.com/opendialogai/opendialog/pull/233