### PR TITLE
AttributeTypeService

### DIFF
--- a/Tests/Feature/CompositeAttributeTest.php
+++ b/Tests/Feature/CompositeAttributeTest.php
@@ -28,15 +28,17 @@ class CompositeAttributeTest extends TestCase
             'array'
         );
 
-        $this->setConfigValue(
-            'opendialog.attribute_engine.custom_attributes',
-            [
-                'c' => ExampleAbstractCompositeAttribute::class,
-                'test_attr' => StringAttribute::class,
-                'total' => IntAttribute::class,
-                'results' => ArrayAttribute::class
-            ]
-        );
+        $this->setCustomAttributeTypes([
+            ExampleAbstractCompositeAttribute::class,
+        ]);
+
+        $this->setCustomAttributes([
+            'c' => ExampleAbstractCompositeAttribute::class,
+            'test_attr' => StringAttribute::class,
+            'total' => IntAttribute::class,
+            'results' => ArrayAttribute::class
+        ]);
+
         $attributeCollectionSerialized = $attributeCollection->jsonSerialize();
         $compositeAttributeFromSerializedCollection = AttributeResolver::getAttributeFor('c', $attributeCollectionSerialized);
 
@@ -68,6 +70,12 @@ class CompositeAttributeTest extends TestCase
         $this->registerSingleInterpreter(new TestInterpreterComposite());
 
         $this->registerSingleAction(new TestAction());
+
+        $this->setCustomAttributeTypes(
+            [
+                ExampleAbstractCompositeAttribute::class,
+            ]
+        );
 
         $this->setCustomAttributes(
             [

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -492,13 +492,23 @@ EOT;
     }
 
     /**
-     * Adds the custom attributes and unsets the ContextService to unbind from the service layer
+     * Adds the custom attributes
      *
-     * @param array $customAttribute
+     * @param array $customAttributes
      */
-    protected function setCustomAttributes(array $customAttribute)
+    protected function setCustomAttributes(array $customAttributes)
     {
-        $this->setConfigValue('opendialog.attribute_engine.custom_attributes', $customAttribute);
+        $this->setConfigValue('opendialog.attribute_engine.custom_attributes', $customAttributes);
+    }
+
+    /**
+     * Adds the custom attribute types
+     *
+     * @param array $customAttributeTypes
+     */
+    protected function setCustomAttributeTypes(array $customAttributeTypes)
+    {
+        $this->setConfigValue('opendialog.attribute_engine.custom_attribute_types', $customAttributeTypes);
     }
 
     protected function conversationWithSceneConditions()

--- a/src/AttributeEngine/AttributeEngineServiceProvider.php
+++ b/src/AttributeEngine/AttributeEngineServiceProvider.php
@@ -6,6 +6,8 @@ namespace OpenDialogAi\AttributeEngine;
 
 use Carbon\Laravel\ServiceProvider;
 use OpenDialogAi\AttributeEngine\AttributeResolver\AttributeResolver;
+use OpenDialogAi\AttributeEngine\AttributeTypeService\AttributeTypeService;
+use OpenDialogAi\AttributeEngine\AttributeTypeService\AttributeTypeServiceInterface;
 
 class AttributeEngineServiceProvider extends ServiceProvider
 {
@@ -22,6 +24,7 @@ class AttributeEngineServiceProvider extends ServiceProvider
 
         $this->app->singleton(AttributeResolver::class, function () {
             $attributeResolver = new AttributeResolver();
+
             $attributeResolver->registerAttributes(config('opendialog.attribute_engine.supported_attributes'));
 
             // Gets custom attributes if they have been set
@@ -30,6 +33,19 @@ class AttributeEngineServiceProvider extends ServiceProvider
             }
 
             return $attributeResolver;
+        });
+
+        $this->app->singleton(AttributeTypeServiceInterface::class, function () {
+            $service = new AttributeTypeService();
+
+            $service->registerAttributeTypes(config('opendialog.attribute_engine.supported_attribute_types'));
+
+            // Gets custom attribute types if they have been set
+            if (is_array(config('opendialog.attribute_engine.custom_attribute_types'))) {
+                $service->registerAttributeTypes(config('opendialog.attribute_engine.custom_attribute_types'));
+            }
+
+            return $service;
         });
     }
 }

--- a/src/AttributeEngine/AttributeResolver/AttributeResolver.php
+++ b/src/AttributeEngine/AttributeResolver/AttributeResolver.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Log;
 use OpenDialogAi\AttributeEngine\Attributes\AbstractAttribute;
 use OpenDialogAi\AttributeEngine\Attributes\AttributeInterface;
 use OpenDialogAi\AttributeEngine\Attributes\StringAttribute;
+use OpenDialogAi\AttributeEngine\AttributeTypeService\AttributeTypeServiceInterface;
 
 /**
  * The AttributeResolver maps from an attribute identifier to the attribute type for that Attribute.
@@ -15,10 +16,12 @@ class AttributeResolver
 {
     /* @var array */
     private $supportedAttributes = [];
+    private $attributeTypeService;
 
     public function __construct()
     {
         $this->supportedAttributes = $this->getSupportedAttributes();
+        $this->attributeTypeService = resolve(AttributeTypeServiceInterface::class);
     }
 
     /**
@@ -32,12 +35,12 @@ class AttributeResolver
     /**
      * Registers an array of attributes. The original set of attributes is preserved so this can be run multiple times
      *
-     * @param $attributes \OpenDialogAi\AttributeEngine\Attributes\AttributeInterface[]
+     * @param $attributes string[]|AttributeInterface[] Array of attribute class names
      */
-    public function registerAttributes($attributes): void
+    public function registerAttributes(array $attributes): void
     {
         foreach ($attributes as $name => $type) {
-            if (class_exists($type) && in_array(AttributeInterface::class, class_implements($type))) {
+            if ($this->attributeTypeService->isAttributeTypeClassRegistered($type)) {
                 $this->supportedAttributes[$name] = $type;
             } else {
                 Log::error(sprintf("Not registering attribute %s - has unknown type %s", $name, $type));
@@ -63,7 +66,7 @@ class AttributeResolver
      *
      * @param string $attributeId
      * @param $value
-     * @return \OpenDialogAi\AttributeEngine\Attributes\AttributeInterface
+     * @return AttributeInterface
      */
     public function getAttributeFor(string $attributeId, $value)
     {

--- a/src/AttributeEngine/AttributeResolver/AttributeResolver.php
+++ b/src/AttributeEngine/AttributeResolver/AttributeResolver.php
@@ -7,6 +7,7 @@ use OpenDialogAi\AttributeEngine\Attributes\AbstractAttribute;
 use OpenDialogAi\AttributeEngine\Attributes\AttributeInterface;
 use OpenDialogAi\AttributeEngine\Attributes\StringAttribute;
 use OpenDialogAi\AttributeEngine\AttributeTypeService\AttributeTypeServiceInterface;
+use OpenDialogAi\AttributeEngine\Exceptions\UnsupportedAttributeTypeException;
 
 /**
  * The AttributeResolver maps from an attribute identifier to the attribute type for that Attribute.
@@ -36,6 +37,7 @@ class AttributeResolver
      * Registers an array of attributes. The original set of attributes is preserved so this can be run multiple times
      *
      * @param $attributes string[]|AttributeInterface[] Array of attribute class names
+     * @throws UnsupportedAttributeTypeException
      */
     public function registerAttributes(array $attributes): void
     {
@@ -43,7 +45,13 @@ class AttributeResolver
             if ($this->attributeTypeService->isAttributeTypeClassRegistered($type)) {
                 $this->supportedAttributes[$name] = $type;
             } else {
-                Log::error(sprintf("Not registering attribute %s - has unknown type %s", $name, $type));
+                Log::error(sprintf(
+                    "Not registering attribute %s as it has an unknown type %s, please ensure all "
+                        . "custom attribute types are registered.",
+                    $name,
+                    $type
+                ));
+                throw new UnsupportedAttributeTypeException();
             }
         }
     }

--- a/src/AttributeEngine/AttributeTypeService/AttributeTypeService.php
+++ b/src/AttributeEngine/AttributeTypeService/AttributeTypeService.php
@@ -1,0 +1,114 @@
+<?php
+
+
+namespace OpenDialogAi\AttributeEngine\AttributeTypeService;
+
+
+use Ds\Map;
+use Illuminate\Support\Facades\Log;
+use OpenDialogAi\AttributeEngine\Attributes\AttributeInterface;
+use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeAlreadyRegisteredException;
+use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeInvalidException;
+use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeNotRegisteredException;
+
+class AttributeTypeService implements AttributeTypeServiceInterface
+{
+    /**
+     * @var Map
+     */
+    private $attributeTypes;
+
+    /**
+     * AttributeTypeService constructor.
+     */
+    public function __construct()
+    {
+        $this->attributeTypes = new Map();
+    }
+
+    /**
+     * @param string|AttributeInterface $attributeType
+     * @return bool
+     */
+    public function isValidAttributeType(string $attributeType): bool
+    {
+        return class_exists($attributeType)
+            && in_array(AttributeInterface::class, class_implements($attributeType));
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getAvailableAttributeTypes(): Map
+    {
+        return $this->attributeTypes;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAttributeTypeAvailable(string $attributeTypeId): bool
+    {
+        return $this->attributeTypes->hasKey($attributeTypeId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isAttributeTypeClassRegistered(string $attributeType): bool
+    {
+        return $this->attributeTypes->hasValue($attributeType);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAttributeTypeClass(string $attributeTypeId): string
+    {
+        if ($this->isAttributeTypeAvailable($attributeTypeId)) {
+            return $this->attributeTypes->get($attributeTypeId);
+        } else {
+            throw new AttributeTypeNotRegisteredException();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function registerAttributeType(string $attributeType): void
+    {
+        if ($this->isValidAttributeType($attributeType)) {
+            if ($this->isAttributeTypeAvailable($attributeType::getType())) {
+                throw new AttributeTypeAlreadyRegisteredException();
+            } else {
+                $this->attributeTypes->put($attributeType::getType(), $attributeType);
+            }
+        } else {
+            throw new AttributeTypeInvalidException();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function registerAttributeTypes(array $attributeTypes): void
+    {
+        foreach ($attributeTypes as $attributeType) {
+            try {
+                $this->registerAttributeType($attributeType);
+            } catch (AttributeTypeAlreadyRegisteredException $e) {
+                Log::warning(sprintf(
+                    'Not registering attribute type \'%s\', an attribute type with the ID \'%s\' is already registered.',
+                    $attributeType,
+                    $attributeType::getType()
+                ));
+            } catch (AttributeTypeInvalidException $e) {
+                Log::warning(sprintf(
+                    'Not registering attribute type \'%s\', the attribute type was invalid.',
+                    $attributeType
+                ));
+            }
+        }
+    }
+}

--- a/src/AttributeEngine/AttributeTypeService/AttributeTypeServiceInterface.php
+++ b/src/AttributeEngine/AttributeTypeService/AttributeTypeServiceInterface.php
@@ -5,6 +5,7 @@ namespace OpenDialogAi\AttributeEngine\AttributeTypeService;
 
 
 use Ds\Map;
+use OpenDialogAi\AttributeEngine\Attributes\AttributeInterface;
 use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeAlreadyRegisteredException;
 use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeInvalidException;
 use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeNotRegisteredException;
@@ -26,16 +27,24 @@ interface AttributeTypeServiceInterface
     /**
      * Returns whether an attribute type with the given ID has been registered.
      *
-     * @param string $attributeTypeId
+     * @param string|AttributeInterface $attributeTypeId
      * @return bool
      */
     public function isAttributeTypeAvailable(string $attributeTypeId): bool;
 
     /**
+     * Returns whether an attribute type with the given class has been registered.
+     *
+     * @param string|AttributeInterface $attributeType
+     * @return bool
+     */
+    public function isAttributeTypeClassRegistered(string $attributeType): bool;
+
+    /**
      * Returns an attribute type class for the given ID.
      *
      * @param string $attributeTypeId
-     * @return string
+     * @return string|AttributeInterface
      * @throws AttributeTypeNotRegisteredException
      */
     public function getAttributeTypeClass(string $attributeTypeId): string;
@@ -43,9 +52,16 @@ interface AttributeTypeServiceInterface
     /**
      * Registers the given attribute class so that it is available via this service.
      *
-     * @param string $attributeTypeClass
+     * @param string|AttributeInterface $attributeType
      * @throws AttributeTypeAlreadyRegisteredException
      * @throws AttributeTypeInvalidException
      */
-    public function registerAttributeType(string $attributeTypeClass): void;
+    public function registerAttributeType(string $attributeType): void;
+
+    /**
+     * Registers the given attribute classes so that they are available via this service.
+     *
+     * @param array|string[]|AttributeInterface[] $attributeTypes
+     */
+    public function registerAttributeTypes(array $attributeTypes): void;
 }

--- a/src/AttributeEngine/AttributeTypeService/AttributeTypeServiceInterface.php
+++ b/src/AttributeEngine/AttributeTypeService/AttributeTypeServiceInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+
+namespace OpenDialogAi\AttributeEngine\AttributeTypeService;
+
+
+use Ds\Map;
+use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeAlreadyRegisteredException;
+use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeInvalidException;
+use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeNotRegisteredException;
+
+interface AttributeTypeServiceInterface
+{
+    /**
+     * Returns a mapping of available attributes types indexed by their attribute type ID, eg.
+     *  [
+     *      'attribute.core.string' => StringAttribute::class,
+     *      'attribute.core.int' => IntAttribute::class,
+     *      ...
+     *  ]
+     *
+     * @return Map
+     */
+    public function getAvailableAttributeTypes(): Map;
+
+    /**
+     * Returns whether an attribute type with the given ID has been registered.
+     *
+     * @param string $attributeTypeId
+     * @return bool
+     */
+    public function isAttributeTypeAvailable(string $attributeTypeId): bool;
+
+    /**
+     * Returns an attribute type class for the given ID.
+     *
+     * @param string $attributeTypeId
+     * @return string
+     * @throws AttributeTypeNotRegisteredException
+     */
+    public function getAttributeTypeClass(string $attributeTypeId): string;
+
+    /**
+     * Registers the given attribute class so that it is available via this service.
+     *
+     * @param string $attributeTypeClass
+     * @throws AttributeTypeAlreadyRegisteredException
+     * @throws AttributeTypeInvalidException
+     */
+    public function registerAttributeType(string $attributeTypeClass): void;
+}

--- a/src/AttributeEngine/Attributes/AbstractAttribute.php
+++ b/src/AttributeEngine/Attributes/AbstractAttribute.php
@@ -33,7 +33,7 @@ abstract class AbstractAttribute implements AttributeInterface
     /**
      * @return string
      */
-    public function getType(): string
+    public static function getType(): string
     {
         return static::$type;
     }

--- a/src/AttributeEngine/Attributes/AttributeInterface.php
+++ b/src/AttributeEngine/Attributes/AttributeInterface.php
@@ -17,7 +17,7 @@ interface AttributeInterface
     /**
      * @return string
      */
-    public function getType(): string;
+    public static function getType(): string;
 
     /**
      * @param array $arg

--- a/src/AttributeEngine/Exceptions/AttributeTypeAlreadyRegisteredException.php
+++ b/src/AttributeEngine/Exceptions/AttributeTypeAlreadyRegisteredException.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace OpenDialogAi\AttributeEngine\Exceptions;
+
+
+use Exception;
+
+class AttributeTypeAlreadyRegisteredException extends Exception
+{
+
+}

--- a/src/AttributeEngine/Exceptions/AttributeTypeInvalidException.php
+++ b/src/AttributeEngine/Exceptions/AttributeTypeInvalidException.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace OpenDialogAi\AttributeEngine\Exceptions;
+
+
+use Exception;
+
+class AttributeTypeInvalidException extends Exception
+{
+
+}

--- a/src/AttributeEngine/Exceptions/AttributeTypeNotRegisteredException.php
+++ b/src/AttributeEngine/Exceptions/AttributeTypeNotRegisteredException.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace OpenDialogAi\AttributeEngine\Exceptions;
+
+
+use Exception;
+
+class AttributeTypeNotRegisteredException extends Exception
+{
+
+}

--- a/src/AttributeEngine/Tests/AttributeResolverServiceTest.php
+++ b/src/AttributeEngine/Tests/AttributeResolverServiceTest.php
@@ -41,15 +41,40 @@ class AttributeResolverServiceTest extends TestCase
         $this->assertEquals(StringAttribute::class, get_class($attribute));
     }
 
-    public function testBindingCustomAttributes()
+    public function testBindingCustomAttributesWithUnregisteredCustomType()
     {
+        // Don't register any attribute types
         $this->setConfigValue(
-            'opendialog.attribute_engine.custom_attributes',
-            ['test_attribute' => StringAttribute::class]
+            'opendialog.attribute_engine.custom_attribute_types',
+            []
         );
 
+        $this->setConfigValue(
+            'opendialog.attribute_engine.custom_attributes',
+            ['test_attribute' => ExampleCustomAttributeType::class]
+        );
+
+        // Our custom attribute type isn't register so we should fallback to a string attribute
         $attributeResolver = $this->getAttributeResolver();
         $this->assertEquals(StringAttribute::class, get_class($attributeResolver->getAttributeFor('test_attribute', null)));
+    }
+
+    public function testBindingCustomAttributesWithRegisteredCustomType()
+    {
+        // Don't register any attribute types
+        $this->setConfigValue(
+            'opendialog.attribute_engine.custom_attribute_types',
+            [ExampleCustomAttributeType::class]
+        );
+
+        $this->setConfigValue(
+            'opendialog.attribute_engine.custom_attributes',
+            ['test_attribute' => ExampleCustomAttributeType::class]
+        );
+
+        // Our custom attribute type isn't register so we should fallback to a string attribute
+        $attributeResolver = $this->getAttributeResolver();
+        $this->assertEquals(ExampleCustomAttributeType::class, get_class($attributeResolver->getAttributeFor('test_attribute', null)));
     }
 
     public function testBadBinding()

--- a/src/AttributeEngine/Tests/AttributeResolverServiceTest.php
+++ b/src/AttributeEngine/Tests/AttributeResolverServiceTest.php
@@ -4,6 +4,7 @@ namespace OpenDialogAi\AttributeEngine\Tests;
 
 use OpenDialogAi\AttributeEngine\AttributeResolver\AttributeResolver;
 use OpenDialogAi\AttributeEngine\Attributes\StringAttribute;
+use OpenDialogAi\AttributeEngine\Exceptions\UnsupportedAttributeTypeException;
 use OpenDialogAi\Core\Tests\TestCase;
 
 class AttributeResolverServiceTest extends TestCase
@@ -54,14 +55,14 @@ class AttributeResolverServiceTest extends TestCase
             ['test_attribute' => ExampleCustomAttributeType::class]
         );
 
-        // Our custom attribute type isn't registered so we should fallback to a string attribute
-        $attributeResolver = $this->getAttributeResolver();
-        $this->assertEquals(StringAttribute::class, get_class($attributeResolver->getAttributeFor('test_attribute', null)));
+        $this->expectException(UnsupportedAttributeTypeException::class);
+
+        // Our custom attribute type isn't registered so we expect an unsupported attribute type exception
+        $this->getAttributeResolver();
     }
 
     public function testBindingCustomAttributesWithRegisteredCustomType()
     {
-        // Don't register any attribute types
         $this->setConfigValue(
             'opendialog.attribute_engine.custom_attribute_types',
             [ExampleCustomAttributeType::class]
@@ -80,14 +81,19 @@ class AttributeResolverServiceTest extends TestCase
     {
         // Bind attribute to non-class
         $this->setConfigValue(
+            'opendialog.attribute_engine.custom_attribute_types',
+            ['nothing']
+        );
+
+        $this->setConfigValue(
             'opendialog.attribute_engine.custom_attributes',
             ['test_attribute' => 'nothing']
         );
 
-        $attributeResolver = $this->getAttributeResolver();
+        $this->expectException(UnsupportedAttributeTypeException::class);
 
-        $attribute = $attributeResolver->getAttributeFor('test_attribute', null);
-        $this->assertEquals(StringAttribute::class, get_class($attribute));
+        // Our custom attribute type isn't valid so we expect an unsupported attribute type exception
+        $this->getAttributeResolver();
     }
 
     /**

--- a/src/AttributeEngine/Tests/AttributeResolverServiceTest.php
+++ b/src/AttributeEngine/Tests/AttributeResolverServiceTest.php
@@ -54,7 +54,7 @@ class AttributeResolverServiceTest extends TestCase
             ['test_attribute' => ExampleCustomAttributeType::class]
         );
 
-        // Our custom attribute type isn't register so we should fallback to a string attribute
+        // Our custom attribute type isn't registered so we should fallback to a string attribute
         $attributeResolver = $this->getAttributeResolver();
         $this->assertEquals(StringAttribute::class, get_class($attributeResolver->getAttributeFor('test_attribute', null)));
     }
@@ -72,7 +72,6 @@ class AttributeResolverServiceTest extends TestCase
             ['test_attribute' => ExampleCustomAttributeType::class]
         );
 
-        // Our custom attribute type isn't register so we should fallback to a string attribute
         $attributeResolver = $this->getAttributeResolver();
         $this->assertEquals(ExampleCustomAttributeType::class, get_class($attributeResolver->getAttributeFor('test_attribute', null)));
     }

--- a/src/AttributeEngine/Tests/AttributeTypeServiceTest.php
+++ b/src/AttributeEngine/Tests/AttributeTypeServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+
+namespace OpenDialogAi\AttributeEngine\Tests;
+
+
+use OpenDialogAi\AttributeEngine\Attributes\ArrayAttribute;
+use OpenDialogAi\AttributeEngine\Attributes\BooleanAttribute;
+use OpenDialogAi\AttributeEngine\Attributes\FloatAttribute;
+use OpenDialogAi\AttributeEngine\Attributes\IntAttribute;
+use OpenDialogAi\AttributeEngine\Attributes\StringAttribute;
+use OpenDialogAi\AttributeEngine\Attributes\TimestampAttribute;
+use OpenDialogAi\AttributeEngine\AttributeTypeService\AttributeTypeServiceInterface;
+use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeAlreadyRegisteredException;
+use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeInvalidException;
+use OpenDialogAi\AttributeEngine\Exceptions\AttributeTypeNotRegisteredException;
+use OpenDialogAi\Core\Tests\TestCase;
+
+class AttributeTypeServiceTest extends TestCase
+{
+    public function testCoreAttributeTypesAreRegistered()
+    {
+        $attributeTypeService = resolve(AttributeTypeServiceInterface::class);
+        $this->assertGreaterThan(0, $attributeTypeService->getAvailableAttributeTypes());
+
+        $this->assertTrue($attributeTypeService->isAttributeTypeAvailable(ArrayAttribute::$type));
+        $this->assertEquals(ArrayAttribute::class, $attributeTypeService->getAttributeTypeClass(ArrayAttribute::$type));
+
+        $this->assertTrue($attributeTypeService->isAttributeTypeAvailable(BooleanAttribute::$type));
+        $this->assertEquals(BooleanAttribute::class, $attributeTypeService->getAttributeTypeClass(BooleanAttribute::$type));
+
+        $this->assertTrue($attributeTypeService->isAttributeTypeAvailable(FloatAttribute::$type));
+        $this->assertEquals(FloatAttribute::class, $attributeTypeService->getAttributeTypeClass(FloatAttribute::$type));
+
+        $this->assertTrue($attributeTypeService->isAttributeTypeAvailable(IntAttribute::$type));
+        $this->assertEquals(IntAttribute::class, $attributeTypeService->getAttributeTypeClass(IntAttribute::$type));
+
+        $this->assertTrue($attributeTypeService->isAttributeTypeAvailable(StringAttribute::$type));
+        $this->assertEquals(StringAttribute::class, $attributeTypeService->getAttributeTypeClass(StringAttribute::$type));
+
+        $this->assertTrue($attributeTypeService->isAttributeTypeAvailable(TimestampAttribute::$type));
+        $this->assertEquals(TimestampAttribute::class, $attributeTypeService->getAttributeTypeClass(TimestampAttribute::$type));
+    }
+
+    public function testGetUnregisteredAttributeType()
+    {
+        $attributeTypeService = resolve(AttributeTypeServiceInterface::class);
+
+        // attribute.app.custom hasn't been registered so when we try to get the attribute type class
+        // we should get this exception
+        $this->expectException(AttributeTypeNotRegisteredException::class);
+        $this->assertFalse($attributeTypeService->isAttributeTypeAvailable(ExampleCustomAttributeType::$type));
+
+        $attributeTypeService->getAttributeTypeClass(ExampleCustomAttributeType::$type);
+    }
+
+    public function testRegisterCustomAttributeType()
+    {
+        $attributeTypeService = resolve(AttributeTypeServiceInterface::class);
+
+        $attributeTypeService->registerAttributeType(ExampleCustomAttributeType::class);
+
+        $this->assertTrue($attributeTypeService->isAttributeTypeAvailable(ExampleCustomAttributeType::$type));
+    }
+
+    public function testRegisterCustomAttributeTypeWithUsedId()
+    {
+        $attributeTypeService = resolve(AttributeTypeServiceInterface::class);
+
+        // attribute.core.string is already used by StringAttribute, so when we try to register
+        // ExampleCustomAttributeWithUsedName (which has the same ID) we should get this exception
+        $this->expectException(AttributeTypeAlreadyRegisteredException::class);
+        $attributeTypeService->registerAttributeType(ExampleCustomAttributeTypeWithUsedName::class);
+    }
+
+    public function testRegisterCustomAttributeTypeWithoutImplementingInterface()
+    {
+        $attributeTypeService = resolve(AttributeTypeServiceInterface::class);
+
+        // ExampleCustomAttributeTypeWithoutImplements doesn't implement AttributeInterface so we should get this exception
+        $this->expectException(AttributeTypeInvalidException::class);
+        $attributeTypeService->registerAttributeType(ExampleCustomAttributeTypeWithoutImplements::class);
+    }
+}

--- a/src/AttributeEngine/Tests/AttributeTypeServiceTest.php
+++ b/src/AttributeEngine/Tests/AttributeTypeServiceTest.php
@@ -21,7 +21,7 @@ class AttributeTypeServiceTest extends TestCase
     public function testCoreAttributeTypesAreRegistered()
     {
         $attributeTypeService = resolve(AttributeTypeServiceInterface::class);
-        $this->assertGreaterThan(0, $attributeTypeService->getAvailableAttributeTypes());
+        $this->assertGreaterThan(0, count($attributeTypeService->getAvailableAttributeTypes()));
 
         $this->assertTrue($attributeTypeService->isAttributeTypeAvailable(ArrayAttribute::$type));
         $this->assertEquals(ArrayAttribute::class, $attributeTypeService->getAttributeTypeClass(ArrayAttribute::$type));

--- a/src/AttributeEngine/Tests/ExampleCustomAttributeType.php
+++ b/src/AttributeEngine/Tests/ExampleCustomAttributeType.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace OpenDialogAi\AttributeEngine\Tests;
+
+
+use OpenDialogAi\AttributeEngine\Attributes\StringAttribute;
+
+class ExampleCustomAttributeType extends StringAttribute
+{
+    /**
+     * @var string
+     */
+    public static $type = 'attribute.app.custom';
+
+    /**
+     * ExampleCustomAttribute constructor.
+     *
+     * @param $id
+     * @param $value
+     */
+    public function __construct($id, $value)
+    {
+        parent::__construct($id, $value);
+    }
+
+    /**
+     * Returns null or an strval prepended with 'custom: '
+     *
+     * @param array $arg
+     *
+     * @return null | string
+     */
+    public function getValue(array $arg = [])
+    {
+        $stringValue = parent::getValue($arg);
+        return is_null($stringValue) ? null : ('custom: ' . $stringValue);
+    }
+}

--- a/src/AttributeEngine/Tests/ExampleCustomAttributeTypeWithUsedName.php
+++ b/src/AttributeEngine/Tests/ExampleCustomAttributeTypeWithUsedName.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace OpenDialogAi\AttributeEngine\Tests;
+
+
+use OpenDialogAi\AttributeEngine\Attributes\StringAttribute;
+
+class ExampleCustomAttributeTypeWithUsedName extends StringAttribute
+{
+    /**
+     * @var string
+     */
+    public static $type = 'attribute.core.string';
+
+    /**
+     * ExampleCustomAttribute constructor.
+     *
+     * @param $id
+     * @param $value
+     */
+    public function __construct($id, $value)
+    {
+        parent::__construct($id, $value);
+    }
+
+    /**
+     * Returns null or an strval prepended with 'custom: '
+     *
+     * @param array $arg
+     *
+     * @return null | string
+     */
+    public function getValue(array $arg = [])
+    {
+        $stringValue = parent::getValue($arg);
+        return is_null($stringValue) ? null : ('custom: ' . $stringValue);
+    }
+}

--- a/src/AttributeEngine/Tests/ExampleCustomAttributeTypeWithoutImplements.php
+++ b/src/AttributeEngine/Tests/ExampleCustomAttributeTypeWithoutImplements.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace OpenDialogAi\AttributeEngine\Tests;
+
+
+class ExampleCustomAttributeTypeWithoutImplements
+{
+    /**
+     * @var string
+     */
+    public static $type = 'attribute.app.custom';
+}

--- a/src/AttributeEngine/config/opendialog-attributeengine-custom.php
+++ b/src/AttributeEngine/config/opendialog-attributeengine-custom.php
@@ -2,6 +2,20 @@
 
 return [
     /**
+     * Register your application specific attribute types here. They should be registered as:
+     * [
+     *   Fully/Qualified/ClassName,
+     *   Fully/Qualified/ClassName2,
+     *   ...
+     * ]
+     *
+     * Where ClassName is an implementation of @see \OpenDialogAi\AttributeEngine\Attributes\AttributeInterface
+     */
+    'custom_attribute_types' => [
+//        \OpenDialogAi\AttributeEngine\Tests\ExampleCustomAttributeType::class
+    ],
+
+    /**
      * Register your application specific attributes here. They should be registered with:
      * {attribute_name} => Fully/Qualified/ClassName
      *

--- a/src/AttributeEngine/config/opendialog-attributeengine.php
+++ b/src/AttributeEngine/config/opendialog-attributeengine.php
@@ -9,6 +9,15 @@ use OpenDialogAi\AttributeEngine\Attributes\TimestampAttribute;
 use OpenDialogAi\Core\Conversation\Model;
 
 return [
+    'supported_attribute_types' => [
+        ArrayAttribute::class,
+        BooleanAttribute::class,
+        FloatAttribute::class,
+        IntAttribute::class,
+        StringAttribute::class,
+        TimestampAttribute::class,
+    ],
+
     'supported_attributes' => [
         'attribute_name'   => StringAttribute::class,
         'attribute_value' => StringAttribute::class,

--- a/src/OperationEngine/Tests/AttributeAccessorConditionTest.php
+++ b/src/OperationEngine/Tests/AttributeAccessorConditionTest.php
@@ -65,14 +65,18 @@ class AttributeAccessorConditionTest extends TestCase
     public function testCompositeAttributesWithUserContext()
     {
         $this->registerSingleInterpreter(new TestInterpreterComposite());
-        $this->setCustomAttributes(
-            [
-                'total' => IntAttribute::class,
-                'results' => ArrayAttribute::class,
-                'array_test' => ArrayAttribute::class,
-                'result_test' => ExampleAbstractCompositeAttribute::class,
-            ]
-        );
+
+        $this->setCustomAttributeTypes([
+            ExampleAbstractCompositeAttribute::class,
+        ]);
+
+        $this->setCustomAttributes([
+            'total' => IntAttribute::class,
+            'results' => ArrayAttribute::class,
+            'array_test' => ArrayAttribute::class,
+            'result_test' => ExampleAbstractCompositeAttribute::class,
+        ]);
+
         $compositeAttributeCollection = new ExampleAbstractCompositeAttribute(
             'result_test',
             new ExampleAbstractAttributeCollection(


### PR DESCRIPTION
This PR adds an `AttributeTypeService` which explicitly registers core and custom attribute types. Previously there was no such registration and the `AttributeResolver` would only validate attribute types for each individual attribute registration. This new service lays the ground work to expose available attribute types in the upcoming reflection API and to enable validation of dynamic attributes (#428).
