### PR TITLE
ActionPerformer

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -66,9 +66,10 @@
             <directory suffix="Test.php">./src/SensorEngine/Tests</directory>
         </testsuite>
 
-<!--    <testsuite name="ConversationEngine">
+        <testsuite name="ConversationEngine">
             <directory suffix="Test.php">./src/ConversationEngine/Tests</directory>
-        </testsuite> -->
+            <exclude>./src/ConversationEngine/Tests/ConversationEngineTest.php</exclude>
+        </testsuite>
 
         <testsuite name="NlpEngine">
             <directory suffix="Test.php">./src/NlpEngine/Tests</directory>

--- a/src/ActionEngine/Actions/ActionInterface.php
+++ b/src/ActionEngine/Actions/ActionInterface.php
@@ -26,13 +26,6 @@ interface ActionInterface
     public static function getRequiredAttributes(): array;
 
     /**
-     * Returns an array of attribute names that the action give as input
-     *
-     * @return Map
-     */
-    public function getInputAttributes(): Map;
-
-    /**
      * Checks whether the action requires the specified attribute
      *
      * @param $attributeName string The name of the attribute to check

--- a/src/ActionEngine/Actions/BaseAction.php
+++ b/src/ActionEngine/Actions/BaseAction.php
@@ -2,7 +2,6 @@
 
 namespace OpenDialogAi\ActionEngine\Actions;
 
-use Ds\Map;
 use OpenDialogAi\Core\Components\Contracts\OpenDialogComponent;
 use OpenDialogAi\Core\Components\ODComponent;
 use OpenDialogAi\Core\Components\ODComponentTypes;
@@ -20,17 +19,6 @@ abstract class BaseAction implements ActionInterface, OpenDialogComponent
     /** @var array|string[] */
     protected static array $outputAttributes = [];
 
-    /** @var Map */
-    private $inputAttributes = [];
-
-    /**
-     * @inheritdoc
-     */
-    public function setInputAttributes($inputAttributes)
-    {
-        $this->inputAttributes = $inputAttributes;
-    }
-
     /**
      * @inheritdoc
      */
@@ -44,15 +32,7 @@ abstract class BaseAction implements ActionInterface, OpenDialogComponent
      */
     public function requiresAttribute($attributeName): bool
     {
-        return in_array($attributeName, $this->requiredAttributes);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function getInputAttributes(): Map
-    {
-        return $this->inputAttributes;
+        return in_array($attributeName, static::$requiredAttributes);
     }
 
     /**
@@ -68,6 +48,6 @@ abstract class BaseAction implements ActionInterface, OpenDialogComponent
      */
     public function outputsAttribute($attributeName): bool
     {
-        return $this->outputAttributes->hasKey($attributeName);
+        return in_array($attributeName, static::$outputAttributes);
     }
 }

--- a/src/ActionEngine/Facades/ActionService.php
+++ b/src/ActionEngine/Facades/ActionService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OpenDialogAi\ActionEngine\Facades;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Facade;
+use OpenDialogAi\ActionEngine\Actions\ActionInterface;
+use OpenDialogAi\ActionEngine\Actions\ActionResult;
+use OpenDialogAi\ActionEngine\Service\ActionEngineInterface;
+
+/**
+ * @method static void setAvailableActions($supportedActions)
+ * @method static void unSetAvailableActions()
+ * @method static array getAvailableActions()
+ * @method static ActionResult performAction(string $actionName, Collection $inputAttributes):
+ * @method static void registerAction(ActionInterface $action)
+*/
+class ActionService extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return ActionEngineInterface::class;
+    }
+}

--- a/src/ActionEngine/Service/ActionEngine.php
+++ b/src/ActionEngine/Service/ActionEngine.php
@@ -2,11 +2,12 @@
 
 namespace OpenDialogAi\ActionEngine\Service;
 
-use Ds\Map;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use OpenDialogAi\ActionEngine\Actions\ActionInput;
 use OpenDialogAi\ActionEngine\Actions\ActionInterface;
 use OpenDialogAi\ActionEngine\Actions\ActionResult;
+use OpenDialogAi\ActionEngine\Actions\BaseAction;
 use OpenDialogAi\AttributeEngine\Exceptions\AttributeDoesNotExistException;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\Core\Components\Exceptions\InvalidComponentDataException;
@@ -15,7 +16,7 @@ use OpenDialogAi\Core\Exceptions\NameNotSetException;
 
 class ActionEngine implements ActionEngineInterface
 {
-    /** @var Action[] */
+    /** @var ActionInterface[] */
     private $availableActions = [];
 
     /**
@@ -88,13 +89,11 @@ class ActionEngine implements ActionEngineInterface
      * Will not run the action if the input attributes do not match the required attributes.
      * @inheritdoc
      */
-    public function performAction(string $actionName, Map $inputAttributes): ActionResult
+    public function performAction(string $actionName, Collection $inputAttributes): ActionResult
     {
         if ($this->actionIsAvailable($actionName)) {
+            /** @var ActionInterface $action */
             $action = $this->availableActions[$actionName];
-            $action->setInputAttributes($inputAttributes);
-
-            $inputAttributes = $action->getInputAttributes();
 
             $actionInput = $this->getActionInput($inputAttributes);
 
@@ -134,12 +133,13 @@ class ActionEngine implements ActionEngineInterface
     /**
      * Loops through all input attributes, tries to get each attribute from the given context and adds to the action input.
      * If the specified attribute does not exist, it is not added to the action input
-     * @param Map $inputAttributes
+     * @param Collection $inputAttributes
      * @return ActionInput
      */
-    private function getActionInput(Map $inputAttributes): ActionInput
+    private function getActionInput(Collection $inputAttributes): ActionInput
     {
         $actionInput = new ActionInput();
+
         foreach ($inputAttributes as $attributeId => $contextId) {
             try {
                 $attribute = ContextService::getAttribute($attributeId, $contextId);
@@ -155,6 +155,7 @@ class ActionEngine implements ActionEngineInterface
                 );
             }
         }
+
         return $actionInput;
     }
 

--- a/src/ActionEngine/Service/ActionEngineInterface.php
+++ b/src/ActionEngine/Service/ActionEngineInterface.php
@@ -2,7 +2,7 @@
 
 namespace OpenDialogAi\ActionEngine\Service;
 
-use Ds\Map;
+use Illuminate\Support\Collection;
 use OpenDialogAi\ActionEngine\Actions\ActionInterface;
 use OpenDialogAi\ActionEngine\Actions\ActionResult;
 use OpenDialogAi\Core\Exceptions\NameNotSetException;
@@ -29,10 +29,10 @@ interface ActionEngineInterface
 
     /**
      * @param string $actionName The name of the action to perform
-     * @param Map $inputAttributes
+     * @param Collection $inputAttributes
      * @return ActionResult|null
      */
-    public function performAction(string $actionName, Map $inputAttributes): ?ActionResult;
+    public function performAction(string $actionName, Collection $inputAttributes): ?ActionResult;
 
     /**
      * Registers an action to the engine. This method is useful for mocking actions in tests.

--- a/src/ActionEngine/Tests/ActionEngineServiceTest.php
+++ b/src/ActionEngine/Tests/ActionEngineServiceTest.php
@@ -2,7 +2,6 @@
 
 namespace OpenDialogAi\ActionEngine\Tests;
 
-use Ds\Map;
 use OpenDialogAi\ActionEngine\Exceptions\ActionNotAvailableException;
 use OpenDialogAi\ActionEngine\Service\ActionEngine;
 use OpenDialogAi\ActionEngine\Service\ActionEngineInterface;
@@ -71,7 +70,7 @@ class ActionEngineServiceTest extends TestCase
 
     public function testPerformActionNotBound()
     {
-        $result = $this->actionEngine->performAction('actions.core.dummy', new Map());
+        $result = $this->actionEngine->performAction('actions.core.dummy', collect());
         $this->assertFalse($result->isSuccessful());
     }
 
@@ -80,7 +79,7 @@ class ActionEngineServiceTest extends TestCase
         $this->setDummyAction();
         $this->createTestContext();
 
-        $inputAttributes = new Map([
+        $inputAttributes = collect([
             'name' => 'test',
         ]);
 
@@ -99,7 +98,7 @@ class ActionEngineServiceTest extends TestCase
 
         ContextService::getContext('test')->addAttribute(new StringAttribute('name', 'value'));
 
-        $inputAttributes = new Map([
+        $inputAttributes = collect([
             'name' => 'test',
         ]);
 
@@ -114,10 +113,10 @@ class ActionEngineServiceTest extends TestCase
     public function testPerformActionWithRequiredAttributes()
     {
         try {
-            $result = $this->actionEngine->performAction('action.core.example', new Map());
+            $result = $this->actionEngine->performAction('action.core.example', collect());
             $this->assertFalse($result->isSuccessful());
 
-            $inputAttributes = new Map([
+            $inputAttributes = collect([
                 'first_name' => 'session',
                 'last_name' => 'session',
             ]);
@@ -142,7 +141,7 @@ class ActionEngineServiceTest extends TestCase
         $testAttribute = new StringAttribute('name', 'John');
         ContextService::getContext('test')->addAttribute($testAttribute);
 
-        $inputAttributes = new Map([
+        $inputAttributes = collect([
             'name' => 'test',
         ]);
 

--- a/src/AttributeEngine/Contracts/AttributeBag.php
+++ b/src/AttributeEngine/Contracts/AttributeBag.php
@@ -2,6 +2,8 @@
 
 namespace OpenDialogAi\AttributeEngine\Contracts;
 
+use Ds\Map;
+
 /**
  * An attribute bag holds a set of attributes that can be set or retrieved
  */
@@ -29,6 +31,13 @@ interface AttributeBag
      * @return mixed
      */
     public function getAttributeValue(string $attributeName);
+
+    /**
+     * Gets all attributes in the bag
+     *
+     * @return Map
+     */
+    public function getAttributes(): Map;
 
     /**
      * Checks whether the attribute with given name exists

--- a/src/Conversation/Action.php
+++ b/src/Conversation/Action.php
@@ -1,0 +1,50 @@
+<?php
+
+
+namespace OpenDialogAi\Core\Conversation;
+
+use Illuminate\Support\Collection;
+
+class Action
+{
+    private string $odId;
+    private Collection $inputAttributes;
+    private Collection $outputAttributes;
+
+    /**
+     * Action constructor.
+     * @param string $odId
+     * @param Collection $inputAttributes
+     * @param Collection $outputAttributes
+     */
+    public function __construct(string $odId, Collection $inputAttributes, Collection $outputAttributes)
+    {
+        $this->odId = $odId;
+        $this->inputAttributes = $inputAttributes;
+        $this->outputAttributes = $outputAttributes;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOdId(): string
+    {
+        return $this->odId;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getInputAttributes(): Collection
+    {
+        return $this->inputAttributes;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getOutputAttributes(): Collection
+    {
+        return $this->outputAttributes;
+    }
+}

--- a/src/Conversation/Action.php
+++ b/src/Conversation/Action.php
@@ -14,14 +14,14 @@ class Action
     /**
      * Action constructor.
      * @param string $odId
-     * @param Collection $inputAttributes
-     * @param Collection $outputAttributes
+     * @param Collection|null $inputAttributes
+     * @param Collection|null $outputAttributes
      */
-    public function __construct(string $odId, Collection $inputAttributes, Collection $outputAttributes)
+    public function __construct(string $odId, ?Collection $inputAttributes = null, ?Collection $outputAttributes = null)
     {
         $this->odId = $odId;
-        $this->inputAttributes = $inputAttributes;
-        $this->outputAttributes = $outputAttributes;
+        $this->inputAttributes = $inputAttributes ?? collect();
+        $this->outputAttributes = $outputAttributes ?? collect();
     }
 
     /**

--- a/src/Conversation/ActionsCollection.php
+++ b/src/Conversation/ActionsCollection.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace OpenDialogAi\Core\Conversation;
+
+
+use Illuminate\Support\Collection;
+
+class ActionsCollection extends Collection
+{
+
+}

--- a/src/Conversation/Intent.php
+++ b/src/Conversation/Intent.php
@@ -42,6 +42,7 @@ class Intent extends ConversationObject
         isset($speaker) ? $this->setSpeaker($speaker) : $this->speaker = null;
         isset($interpreter) ? $this->$interpreter = $interpreter : $this->interpreter = null;
         $this->interpretedIntents = new IntentCollection();
+        $this->actions = new ActionsCollection();
     }
 
     public function getTurn(): ?Turn

--- a/src/Conversation/Intent.php
+++ b/src/Conversation/Intent.php
@@ -2,7 +2,6 @@
 namespace OpenDialogAi\Core\Conversation;
 
 use Ds\Map;
-use OpenDialogAi\AttributeEngine\AttributeBag\BasicAttributeBag;
 use OpenDialogAi\AttributeEngine\AttributeBag\HasAttributesTrait;
 use OpenDialogAi\Core\Conversation\Exceptions\InvalidSpeakerTypeException;
 
@@ -31,6 +30,8 @@ class Intent extends ConversationObject
     // The interpreted intents is a collection interpretations of this intent that are added through an interpreter.
     protected IntentCollection $interpretedIntents;
     protected Intent $interpretation;
+
+    protected ActionsCollection $actions;
 
     public function __construct(?Turn $turn = null, ?string $speaker = null, ?string $interpreter = null)
     {
@@ -172,5 +173,23 @@ class Intent extends ConversationObject
         $intent->setODId($odId);
         $intent->setConfidence($confidence);
         return $intent;
+    }
+
+    /**
+     * @return ActionsCollection
+     */
+    public function getActions(): ActionsCollection
+    {
+        return $this->actions;
+    }
+
+    /**
+     * @param ActionsCollection $actions
+     * @return Intent
+     */
+    public function setActions(ActionsCollection $actions): Intent
+    {
+        $this->actions = $actions;
+        return $this;
     }
 }

--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -18,6 +18,7 @@ use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\IntentCollection;
 use OpenDialogAi\Core\Conversation\Scenario;
+use OpenDialogAi\Core\Conversation\Scene;
 use OpenDialogAi\Core\Conversation\Turn;
 use OpenDialogAi\InterpreterEngine\Service\InterpreterServiceInterface;
 use OpenDialogAi\OperationEngine\Service\OperationServiceInterface;

--- a/src/ConversationEngine/Reasoners/ActionPerformer.php
+++ b/src/ConversationEngine/Reasoners/ActionPerformer.php
@@ -17,9 +17,21 @@ use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\Core\Conversation\Action;
 use OpenDialogAi\Core\Conversation\ActionsCollection;
 use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\IntentCollection;
 
 class ActionPerformer
 {
+    /**
+     * Performs all actions associated with the given intents
+     *
+     * @param IntentCollection $intents
+     */
+    public static function performActionsForIntents(IntentCollection $intents): void
+    {
+        foreach ($intents as $intent) {
+            self::performActionsForIntent($intent);
+        }
+    }
     /**
      * Performs all actions associated with the given intent
      *

--- a/src/ConversationEngine/Reasoners/ActionPerformer.php
+++ b/src/ConversationEngine/Reasoners/ActionPerformer.php
@@ -7,8 +7,8 @@ namespace OpenDialogAi\ConversationEngine\Reasoners;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use OpenDialogAi\ActionEngine\Facades\ActionService;
-use OpenDialogAi\AttributeEngine\AttributeBag\BasicAttributeBag;
 use OpenDialogAi\AttributeEngine\Contracts\Attribute;
+use OpenDialogAi\AttributeEngine\Contracts\AttributeBag;
 use OpenDialogAi\ContextEngine\Contexts\BaseContexts\SessionContext;
 use OpenDialogAi\ContextEngine\Exceptions\ContextDoesNotExistException;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
@@ -75,10 +75,10 @@ class ActionPerformer
 
     /**
      * @param Collection $parsedInputAttributes
-     * @param BasicAttributeBag $resultAttributes
+     * @param AttributeBag $resultAttributes
      * @return Collection
      */
-    private static function createContextMap(Collection $parsedInputAttributes, BasicAttributeBag $resultAttributes): Collection
+    private static function createContextMap(Collection $parsedInputAttributes, AttributeBag $resultAttributes): Collection
     {
         return collect($resultAttributes->getAttributes()->toArray())
             ->mapWithKeys(function (Attribute $attribute) use ($parsedInputAttributes) {
@@ -92,9 +92,9 @@ class ActionPerformer
 
     /**
      * @param Collection $contextAttributeMap
-     * @param BasicAttributeBag $resultAttributes
+     * @param AttributeBag $resultAttributes
      */
-    private static function saveAttributesToContexts(Collection $contextAttributeMap, BasicAttributeBag $resultAttributes): void
+    private static function saveAttributesToContexts(Collection $contextAttributeMap, AttributeBag $resultAttributes): void
     {
         foreach ($contextAttributeMap as $attributeId => $contextId) {
             $attribute = $resultAttributes->getAttribute($attributeId);

--- a/src/ConversationEngine/Reasoners/ActionPerformer.php
+++ b/src/ConversationEngine/Reasoners/ActionPerformer.php
@@ -4,6 +4,16 @@
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
 
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use OpenDialogAi\ActionEngine\Service\ActionEngineInterface;
+use OpenDialogAi\AttributeEngine\AttributeBag\BasicAttributeBag;
+use OpenDialogAi\AttributeEngine\Contracts\Attribute;
+use OpenDialogAi\ContextEngine\Contexts\BaseContexts\SessionContext;
+use OpenDialogAi\ContextEngine\Contexts\PersistentContext;
+use OpenDialogAi\ContextEngine\Contracts\Context;
+use OpenDialogAi\ContextEngine\Exceptions\ContextDoesNotExistException;
+use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\Core\Conversation\Action;
 use OpenDialogAi\Core\Conversation\ActionsCollection;
 use OpenDialogAi\Core\Conversation\Intent;
@@ -17,17 +27,19 @@ class ActionPerformer
      */
     public static function performActionsForIntent(Intent $intent): void
     {
-
+        self::performActions($intent->getActions());
     }
 
     /**
      * Performs all actions in the given collection
      *
-     * @param ActionsCollection $actions
+     * @param ActionsCollection|Action[] $actions
      */
     public static function performActions(ActionsCollection $actions): void
     {
-
+        foreach ($actions as $action) {
+            self::performAction($action);
+        }
     }
 
     /**
@@ -37,6 +49,81 @@ class ActionPerformer
      */
     public static function performAction(Action $action): void
     {
+        $inputAttributes = $action->getInputAttributes();
 
+        $actionResult = resolve(ActionEngineInterface::class)->performAction(
+            $action->getOdId(),
+            $inputAttributes
+        );
+
+        // Store desired result attributes in desired contents (use session otherwise)
+        $resultAttributes = $actionResult->getResultAttributes();
+        $contextAttributeMap = self::createContextMap($inputAttributes, $resultAttributes);
+
+        self::saveAttributesToContexts($contextAttributeMap, $resultAttributes);
+
+        // Loop thru dirtied contexts and persist
+        self::persistUpdatedContexts($contextAttributeMap);
+    }
+
+    /**
+     * @param Collection $parsedInputAttributes
+     * @param BasicAttributeBag $resultAttributes
+     * @return Collection
+     */
+    private static function createContextMap(Collection $parsedInputAttributes, BasicAttributeBag $resultAttributes): Collection
+    {
+        return collect($resultAttributes->getAttributes()->toArray())
+            ->mapWithKeys(function (Attribute $attribute) use ($parsedInputAttributes) {
+                $context = $parsedInputAttributes->has($attribute->getId())
+                    ? $parsedInputAttributes->get($attribute->getId())
+                    : SessionContext::getComponentId();
+
+                return [ $attribute->getId() => $context ];
+            });
+    }
+
+    /**
+     * @param Collection $contextAttributeMap
+     * @param BasicAttributeBag $resultAttributes
+     */
+    private static function saveAttributesToContexts(Collection $contextAttributeMap, BasicAttributeBag $resultAttributes): void
+    {
+        foreach ($contextAttributeMap as $attributeId => $contextId) {
+            $attribute = $resultAttributes->getAttribute($attributeId);
+
+            try {
+                $context = ContextService::getContext($contextId);
+            } catch (ContextDoesNotExistException $e) {
+                $context = ContextService::getSessionContext();
+                Log::debug(sprintf(
+                    "'%s' saved to session context as provided content '%s' is not registered.",
+                    $attributeId,
+                    $contextId
+                ));
+            }
+
+            $context->addAttribute($attribute);
+        }
+    }
+
+    /**
+     * @param Collection $contextAttributeMap
+     */
+    private static function persistUpdatedContexts(Collection $contextAttributeMap): void
+    {
+        $updatedContexts = $contextAttributeMap->values()->unique();
+        foreach ($updatedContexts as $updatedContext) {
+            /** @var Context $updatedContext */
+            if ($updatedContext instanceof PersistentContext) {
+                $persistenceSuccessful = $updatedContext->persist();
+
+                if (!$persistenceSuccessful) {
+                    Log::warning(sprintf(
+                        "Attempted to persist context '%s' but was unsuccessful.", $updatedContext->getId()
+                    ));
+                }
+            }
+        }
     }
 }

--- a/src/ConversationEngine/Reasoners/ActionPerformer.php
+++ b/src/ConversationEngine/Reasoners/ActionPerformer.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace OpenDialogAi\ConversationEngine\Reasoners;
+
+
+use OpenDialogAi\Core\Conversation\Action;
+use OpenDialogAi\Core\Conversation\ActionsCollection;
+use OpenDialogAi\Core\Conversation\Intent;
+
+class ActionPerformer
+{
+    /**
+     * Performs all actions associated with the given intent
+     *
+     * @param Intent $intent
+     */
+    public static function performActionsForIntent(Intent $intent): void
+    {
+
+    }
+
+    /**
+     * Performs all actions in the given collection
+     *
+     * @param ActionsCollection $actions
+     */
+    public static function performActions(ActionsCollection $actions): void
+    {
+
+    }
+
+    /**
+     * Performs the given action
+     *
+     * @param Action $action
+     */
+    public static function performAction(Action $action): void
+    {
+
+    }
+}

--- a/src/ConversationEngine/Reasoners/ActionPerformer.php
+++ b/src/ConversationEngine/Reasoners/ActionPerformer.php
@@ -10,8 +10,6 @@ use OpenDialogAi\ActionEngine\Service\ActionEngineInterface;
 use OpenDialogAi\AttributeEngine\AttributeBag\BasicAttributeBag;
 use OpenDialogAi\AttributeEngine\Contracts\Attribute;
 use OpenDialogAi\ContextEngine\Contexts\BaseContexts\SessionContext;
-use OpenDialogAi\ContextEngine\Contexts\PersistentContext;
-use OpenDialogAi\ContextEngine\Contracts\Context;
 use OpenDialogAi\ContextEngine\Exceptions\ContextDoesNotExistException;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\Core\Conversation\Action;
@@ -124,17 +122,15 @@ class ActionPerformer
      */
     private static function persistUpdatedContexts(Collection $contextAttributeMap): void
     {
-        $updatedContexts = $contextAttributeMap->values()->unique();
-        foreach ($updatedContexts as $updatedContext) {
-            /** @var Context $updatedContext */
-            if ($updatedContext instanceof PersistentContext) {
-                $persistenceSuccessful = $updatedContext->persist();
+        $updatedContextIds = $contextAttributeMap->values()->unique();
+        foreach ($updatedContextIds as $updatedContextId) {
+            $updatedContext = ContextService::getContext($updatedContextId);
+            $persistenceSuccessful = $updatedContext->persist();
 
-                if (!$persistenceSuccessful) {
-                    Log::warning(sprintf(
-                        "Attempted to persist context '%s' but was unsuccessful.", $updatedContext->getId()
-                    ));
-                }
+            if (!$persistenceSuccessful) {
+                Log::warning(sprintf(
+                    "Attempted to persist context '%s' but was unsuccessful.", $updatedContextId->getId()
+                ));
             }
         }
     }

--- a/src/ConversationEngine/Reasoners/ActionPerformer.php
+++ b/src/ConversationEngine/Reasoners/ActionPerformer.php
@@ -6,7 +6,7 @@ namespace OpenDialogAi\ConversationEngine\Reasoners;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
-use OpenDialogAi\ActionEngine\Service\ActionEngineInterface;
+use OpenDialogAi\ActionEngine\Facades\ActionService;
 use OpenDialogAi\AttributeEngine\AttributeBag\BasicAttributeBag;
 use OpenDialogAi\AttributeEngine\Contracts\Attribute;
 use OpenDialogAi\ContextEngine\Contexts\BaseContexts\SessionContext;
@@ -61,10 +61,7 @@ class ActionPerformer
     {
         $inputAttributes = $action->getInputAttributes();
 
-        $actionResult = resolve(ActionEngineInterface::class)->performAction(
-            $action->getOdId(),
-            $inputAttributes
-        );
+        $actionResult = ActionService::performAction($action->getOdId(), $inputAttributes);
 
         // Store desired result attributes in desired contents (use session otherwise)
         $resultAttributes = $actionResult->getResultAttributes();

--- a/src/ConversationEngine/Tests/ActionPerformerTest.php
+++ b/src/ConversationEngine/Tests/ActionPerformerTest.php
@@ -7,7 +7,7 @@ use Mockery;
 use OpenDialogAi\ActionEngine\Actions\ActionInput;
 use OpenDialogAi\ActionEngine\Actions\ActionResult;
 use OpenDialogAi\ActionEngine\Actions\BaseAction;
-use OpenDialogAi\ActionEngine\Service\ActionEngineInterface;
+use OpenDialogAi\ActionEngine\Facades\ActionService;
 use OpenDialogAi\AttributeEngine\Facades\AttributeResolver;
 use OpenDialogAi\ContextEngine\Contexts\BaseContexts\SessionContext;
 use OpenDialogAi\ContextEngine\Contexts\User\UserContext;
@@ -77,7 +77,7 @@ class ActionPerformerTest extends TestCase
 
     public function testActionPerformerWithMultipleDependentActions()
     {
-        resolve(ActionEngineInterface::class)->registerAction(new class extends BaseAction {
+        ActionService::registerAction(new class extends BaseAction {
             protected static string $componentId = 'action.test.plus_five';
 
             protected static array $inputAttributes = ['age'];
@@ -96,7 +96,7 @@ class ActionPerformerTest extends TestCase
             }
         });
 
-        resolve(ActionEngineInterface::class)->registerAction(new class extends BaseAction {
+        ActionService::registerAction(new class extends BaseAction {
             protected static string $componentId = 'action.test.times_three';
 
             protected static array $inputAttributes = ['age'];
@@ -177,7 +177,7 @@ class ActionPerformerTest extends TestCase
 
     private function registerUppercaseFirstNameAction(): void
     {
-        resolve(ActionEngineInterface::class)->registerAction(new class extends BaseAction {
+        ActionService::registerAction(new class extends BaseAction {
             protected static string $componentId = 'action.test.first_name_uppercase';
 
             protected static array $inputAttributes = ['first_name'];

--- a/src/ConversationEngine/Tests/ActionPerformerTest.php
+++ b/src/ConversationEngine/Tests/ActionPerformerTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace OpenDialogAi\ConversationEngine\Tests;
+
+
+use OpenDialogAi\ActionEngine\Actions\ActionInput;
+use OpenDialogAi\ActionEngine\Actions\ActionResult;
+use OpenDialogAi\ActionEngine\Actions\BaseAction;
+use OpenDialogAi\ActionEngine\Service\ActionEngineInterface;
+use OpenDialogAi\AttributeEngine\Facades\AttributeResolver;
+use OpenDialogAi\ContextEngine\Contexts\BaseContexts\SessionContext;
+use OpenDialogAi\ContextEngine\Facades\ContextService;
+use OpenDialogAi\ConversationEngine\Reasoners\ActionPerformer;
+use OpenDialogAi\Core\Conversation\Action;
+use OpenDialogAi\Core\Conversation\ActionsCollection;
+use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Tests\TestCase;
+
+class ActionPerformerTest extends TestCase
+{
+    public function testActionPerformerWithEmptyAction()
+    {
+        $action = new Action('action.fake.unknown');
+
+        ActionPerformer::performAction($action);
+
+        // Assert that the performer silently skipped the fake action
+        $this->assertTrue(true);
+    }
+
+    public function testActionPerformerWithAction()
+    {
+        $this->registerUppercaseFirstNameAction();
+
+        ContextService::saveAttribute(SessionContext::getComponentId().'.first_name', 'my_name');
+
+        $action = new Action('action.test.first_name_uppercase', null, collect([
+            'session.first_name'
+        ]));
+
+        ActionPerformer::performAction($action);
+
+        $this->assertEquals(
+            'MY_NAME',
+            ContextService::getAttributeValue('first_name', SessionContext::getComponentId())
+        );
+    }
+
+    public function testActionPerformerWithMultipleDependentActions()
+    {
+        resolve(ActionEngineInterface::class)->registerAction(new class extends BaseAction {
+            protected static string $componentId = 'action.test.plus_five';
+
+            protected static array $inputAttributes = ['age'];
+            protected static array $outputAttributes = ['age'];
+
+            /**
+             * @inheritDoc
+             */
+            public function perform(ActionInput $actionInput): ActionResult
+            {
+                $age = $actionInput->getAttributeBag()->getAttributeValue('age');
+
+                return ActionResult::createSuccessfulActionResultWithAttributes([
+                    AttributeResolver::getAttributeFor('age', $age + 5)
+                ]);
+            }
+        });
+
+        resolve(ActionEngineInterface::class)->registerAction(new class extends BaseAction {
+            protected static string $componentId = 'action.test.times_three';
+
+            protected static array $inputAttributes = ['age'];
+            protected static array $outputAttributes = ['age'];
+
+            /**
+             * @inheritDoc
+             */
+            public function perform(ActionInput $actionInput): ActionResult
+            {
+                $age = $actionInput->getAttributeBag()->getAttributeValue('age');
+
+                return ActionResult::createSuccessfulActionResultWithAttributes([
+                    AttributeResolver::getAttributeFor('age', $age * 3)
+                ]);
+            }
+        });
+
+        $initialNumber = 25;
+        ContextService::saveAttribute(SessionContext::getComponentId().'.age', $initialNumber);
+
+        $plusFiveAction = new Action('action.test.plus_five', collect([
+            'session.age'
+        ]), collect([
+            'session.age'
+        ]));
+
+        $timesThreeAction = new Action('action.test.times_three', collect([
+            'session.age'
+        ]), collect([
+            'session.age'
+        ]));
+
+        ActionPerformer::performActions(new ActionsCollection([
+            $plusFiveAction,
+            $timesThreeAction,
+            $plusFiveAction,
+        ]));
+
+        $this->assertEquals(
+            (($initialNumber + 5) * 3) + 5,
+            ContextService::getAttributeValue('age', SessionContext::getComponentId())
+        );
+    }
+
+
+    public function testActionPerformerWithIntent()
+    {
+        $this->registerUppercaseFirstNameAction();
+
+        ContextService::saveAttribute(SessionContext::getComponentId().'.first_name', 'my_name');
+
+        $action = new Action('action.test.first_name_uppercase', null, collect([
+            'session.first_name'
+        ]));
+
+        $intent = new Intent();
+        $intent->setActions(new ActionsCollection([
+            $action
+        ]));
+
+        ActionPerformer::performActionsForIntent($intent);
+
+        $this->assertEquals(
+            'MY_NAME',
+            ContextService::getAttributeValue('first_name', SessionContext::getComponentId())
+        );
+    }
+
+    private function registerUppercaseFirstNameAction(): void
+    {
+        resolve(ActionEngineInterface::class)->registerAction(new class extends BaseAction {
+            protected static string $componentId = 'action.test.first_name_uppercase';
+
+            protected static array $inputAttributes = ['first_name'];
+            protected static array $outputAttributes = ['first_name'];
+
+            /**
+             * @inheritDoc
+             */
+            public function perform(ActionInput $actionInput): ActionResult
+            {
+                $firstName = $actionInput->getAttributeBag()->getAttributeValue('first_name');
+
+                return ActionResult::createSuccessfulActionResultWithAttributes([
+                    AttributeResolver::getAttributeFor('first_name', strtoupper($firstName))
+                ]);
+            }
+        });
+    }
+}

--- a/src/ConversationEngine/Tests/ActionPerformerTest.php
+++ b/src/ConversationEngine/Tests/ActionPerformerTest.php
@@ -28,23 +28,26 @@ class ActionPerformerTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function testActionPerformerWithAction()
+    public function testActionPerformerWithActionAndCompositeAttributes()
     {
         $this->registerUppercaseFirstNameAction();
 
-        ContextService::saveAttribute(SessionContext::getComponentId().'.first_name', 'my_name');
+        ContextService::saveAttribute(
+            SessionContext::getComponentId().'.composite',
+            AttributeResolver::getAttributeFor('first_name', 'my_name')
+        );
 
         $action = new Action('action.test.first_name_uppercase', collect([
-            'first_name' => 'session'
+            'composite.first_name' => 'session'
         ]), collect([
-            'first_name' => 'session'
+            'composite.first_name' => 'session'
         ]));
 
         ActionPerformer::performAction($action);
 
         $this->assertEquals(
             'MY_NAME',
-            ContextService::getAttributeValue('first_name', SessionContext::getComponentId())
+            ContextService::getAttributeValue('composite.first_name', SessionContext::getComponentId())
         );
     }
 

--- a/src/ConversationEngine/Tests/ActionPerformerTest.php
+++ b/src/ConversationEngine/Tests/ActionPerformerTest.php
@@ -34,8 +34,10 @@ class ActionPerformerTest extends TestCase
 
         ContextService::saveAttribute(SessionContext::getComponentId().'.first_name', 'my_name');
 
-        $action = new Action('action.test.first_name_uppercase', null, collect([
-            'session.first_name'
+        $action = new Action('action.test.first_name_uppercase', collect([
+            'first_name' => 'session'
+        ]), collect([
+            'first_name' => 'session'
         ]));
 
         ActionPerformer::performAction($action);
@@ -90,15 +92,15 @@ class ActionPerformerTest extends TestCase
         ContextService::saveAttribute(SessionContext::getComponentId().'.age', $initialNumber);
 
         $plusFiveAction = new Action('action.test.plus_five', collect([
-            'session.age'
+            'age' => 'session'
         ]), collect([
-            'session.age'
+            'age' => 'session'
         ]));
 
         $timesThreeAction = new Action('action.test.times_three', collect([
-            'session.age'
+            'age' => 'session'
         ]), collect([
-            'session.age'
+            'age' => 'session'
         ]));
 
         ActionPerformer::performActions(new ActionsCollection([
@@ -120,8 +122,10 @@ class ActionPerformerTest extends TestCase
 
         ContextService::saveAttribute(SessionContext::getComponentId().'.first_name', 'my_name');
 
-        $action = new Action('action.test.first_name_uppercase', null, collect([
-            'session.first_name'
+        $action = new Action('action.test.first_name_uppercase', collect([
+            'first_name' => 'session'
+        ]), collect([
+            'first_name' => 'session'
         ]));
 
         $intent = new Intent();

--- a/src/ConversationEngine/Tests/ActionPerformerTest.php
+++ b/src/ConversationEngine/Tests/ActionPerformerTest.php
@@ -31,26 +31,47 @@ class ActionPerformerTest extends TestCase
         $this->assertTrue(true);
     }
 
-    public function testActionPerformerWithActionAndCompositeAttributes()
+    public function testActionPerformerWithAction()
     {
         $this->registerUppercaseFirstNameAction();
 
-        ContextService::saveAttribute(
-            SessionContext::getComponentId().'.composite',
-            AttributeResolver::getAttributeFor('first_name', 'my_name')
-        );
+        ContextService::saveAttribute(SessionContext::getComponentId().'.first_name', 'my_name');
 
         $action = new Action('action.test.first_name_uppercase', collect([
-            'composite.first_name' => 'session'
+            'first_name' => 'session'
         ]), collect([
-            'composite.first_name' => 'session'
+            'first_name' => 'session'
         ]));
 
         ActionPerformer::performAction($action);
 
         $this->assertEquals(
             'MY_NAME',
-            ContextService::getAttributeValue('composite.first_name', SessionContext::getComponentId())
+            ContextService::getAttributeValue('first_name', SessionContext::getComponentId())
+        );
+    }
+
+    /**
+     * This test is currently skipped pending further work on composite attributes
+     * @group skip
+     */
+    public function testActionPerformerWithActionAndCompositeAttributes()
+    {
+        $this->registerUppercaseFirstNameAction();
+
+        ContextService::saveAttribute(SessionContext::getComponentId().'.composite[first_name]', 'my_name');
+
+        $action = new Action('action.test.first_name_uppercase', collect([
+            'composite[first_name]' => 'session'
+        ]), collect([
+            'composite[first_name]' => 'session'
+        ]));
+
+        ActionPerformer::performAction($action);
+
+        $this->assertEquals(
+            'MY_NAME',
+            ContextService::getAttributeValue('composite[first_name]', SessionContext::getComponentId())
         );
     }
 


### PR DESCRIPTION
This PR adds an `ActionPerformer` class that:

 - defines methods that take input of `Intent`(s) or `Action`(s),
 - provide the actions with the desired attribute inputs,
 - perform the associated actions,
 - take the actions result attributes and store them in the desired contexts,
 - and persists any updated persistent contexts.