### PR TITLE
ConditionFilter

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -66,9 +66,10 @@
             <directory suffix="Test.php">./src/SensorEngine/Tests</directory>
         </testsuite>
 
-<!--    <testsuite name="ConversationEngine">
+        <testsuite name="ConversationEngine">
             <directory suffix="Test.php">./src/ConversationEngine/Tests</directory>
-        </testsuite> -->
+            <exclude>./src/ConversationEngine/Tests/ConversationEngineTest.php</exclude>
+        </testsuite>
 
         <testsuite name="NlpEngine">
             <directory suffix="Test.php">./src/NlpEngine/Tests</directory>

--- a/src/Conversation/ConversationObject.php
+++ b/src/Conversation/ConversationObject.php
@@ -141,6 +141,15 @@ class ConversationObject
     }
 
     /**
+     * @param ConditionCollection $conditions
+     * @return void
+     */
+    public function setConditions(ConditionCollection $conditions): void
+    {
+        $this->conditions = $conditions;
+    }
+
+    /**
      * Indicates whether an object is associates with behaviors.
      * @return bool
      */

--- a/src/ConversationEngine/Reasoners/ConditionFilter.php
+++ b/src/ConversationEngine/Reasoners/ConditionFilter.php
@@ -18,7 +18,9 @@ class ConditionFilter
      */
     public static function filterObjects(ODObjectCollection $objects): ODObjectCollection
     {
-        return $objects;
+        return $objects->filter(function (ConversationObject $object) {
+            return self::checkConditionsForObject($object);
+        });
     }
 
     /**
@@ -29,20 +31,7 @@ class ConditionFilter
      */
     public static function checkConditionsForObject(ConversationObject $object): bool
     {
-        $conditions = $object->getConditions();
-        // Check each condition in turn to see if it passes
-        $passingConditions = $conditions->filter(function ($condition) {
-            if (OperationService::checkCondition($condition)) {
-                return true;
-            }
-            return false;
-        });
-        //If all the conditions passed we return true
-        if (count($passingConditions) == count ($conditions)) {
-            return true;
-        }
-
-        return false;
+        return self::checkConditions($object->getConditions());
     }
 
     /**
@@ -53,7 +42,20 @@ class ConditionFilter
      */
     public static function checkConditions(ConditionCollection $conditions): bool
     {
-        return false;
+        $allConditionsPassed = true;
+
+        $conditions->each(function (Condition $condition) use (&$allConditionsPassed) {
+            $conditionPassed = self::checkCondition($condition);
+
+            if (!$conditionPassed) {
+                $allConditionsPassed = false;
+            }
+
+            // Will break when this returns false
+            return $conditionPassed;
+        });
+
+        return $allConditionsPassed;
     }
 
     /**
@@ -64,6 +66,6 @@ class ConditionFilter
      */
     public static function checkCondition(Condition $condition): bool
     {
-        return false;
+        return OperationService::checkCondition($condition);
     }
 }

--- a/src/ConversationEngine/Reasoners/ConditionFilter.php
+++ b/src/ConversationEngine/Reasoners/ConditionFilter.php
@@ -4,12 +4,30 @@
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
 
+use OpenDialogAi\Core\Conversation\Condition;
+use OpenDialogAi\Core\Conversation\ConditionCollection;
 use OpenDialogAi\Core\Conversation\ConversationObject;
+use OpenDialogAi\Core\Conversation\ODObjectCollection;
 use OpenDialogAi\OperationEngine\Facade\OperationService;
 
 class ConditionFilter
 {
-    public static function checkConditions(ConversationObject $object): bool
+    /**
+     * @param ODObjectCollection $objects
+     * @return ODObjectCollection
+     */
+    public static function filterObjects(ODObjectCollection $objects): ODObjectCollection
+    {
+        return $objects;
+    }
+
+    /**
+     * Returns whether the conditions for the given object all passed
+     *
+     * @param ConversationObject $object
+     * @return bool
+     */
+    public static function checkConditionsForObject(ConversationObject $object): bool
     {
         $conditions = $object->getConditions();
         // Check each condition in turn to see if it passes
@@ -24,6 +42,28 @@ class ConditionFilter
             return true;
         }
 
+        return false;
+    }
+
+    /**
+     * Returns whether the conditions all passed
+     *
+     * @param ConditionCollection $conditions
+     * @return bool
+     */
+    public static function checkConditions(ConditionCollection $conditions): bool
+    {
+        return false;
+    }
+
+    /**
+     * Returns whether the condition passed
+     *
+     * @param Condition $condition
+     * @return bool
+     */
+    public static function checkCondition(Condition $condition): bool
+    {
         return false;
     }
 }

--- a/src/ConversationEngine/Reasoners/ConversationSelector.php
+++ b/src/ConversationEngine/Reasoners/ConversationSelector.php
@@ -15,13 +15,13 @@ class ConversationSelector
 {
     public static function selectStartingConversations(ScenarioCollection $scenarios): ConversationCollection
     {
+        /** @var ConversationCollection $conversations */
         $conversations = ConversationDataClient::getAllStartingConversations($scenarios);
 
-        $conditionPassingConversations = $conversations->filter(function ($conversation) {
-            ConditionFilter::checkConditions($conversation);
-        });
+        /** @var ConversationCollection $conversationsWithPassingConditions */
+        $conversationsWithPassingConditions = ConditionFilter::filterObjects($conversations);
 
-        return $conditionPassingConversations;
+        return $conversationsWithPassingConditions;
     }
 
 }

--- a/src/ConversationEngine/Reasoners/ScenarioSelector.php
+++ b/src/ConversationEngine/Reasoners/ScenarioSelector.php
@@ -4,7 +4,6 @@
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
-use OpenDialogAi\Core\Conversation\Scenario;
 use OpenDialogAi\Core\Conversation\ScenarioCollection;
 
 /**
@@ -15,12 +14,13 @@ class ScenarioSelector
 {
     public static function selectActiveScenarios(): ScenarioCollection
     {
+        /** @var ScenarioCollection $scenarios */
         $scenarios = ConversationDataClient::getAllActiveScenarios();
 
-        $conditionPassingScenarios = $scenarios->filter(function ($scenario) {
-            return ConditionFilter::checkConditions($scenario);
-        });
-        return $conditionPassingScenarios;
+        /** @var ScenarioCollection $scenariosWithPassingConditions */
+        $scenariosWithPassingConditions = ConditionFilter::filterObjects($scenarios);
+
+        return $scenariosWithPassingConditions;
     }
 
 }

--- a/src/ConversationEngine/Reasoners/SceneSelector.php
+++ b/src/ConversationEngine/Reasoners/SceneSelector.php
@@ -14,12 +14,12 @@ class SceneSelector
 {
     public static function selectStartingScenes($conversations): SceneCollection
     {
+        /** @var SceneCollection $scenes */
         $scenes = ConversationDataClient::getAllStartingScenes($conversations);
 
-        $conditionPassingScenes = $scenes->filter(function ($scene) {
-            ConditionFilter::checkConditions($scene);
-        });
+        /** @var SceneCollection $scenesWithPassingConditions */
+        $scenesWithPassingConditions = ConditionFilter::filterObjects($scenes);
 
-        return $conditionPassingScenes;
+        return $scenesWithPassingConditions;
     }
 }

--- a/src/ConversationEngine/Reasoners/StartingIntentSelector.php
+++ b/src/ConversationEngine/Reasoners/StartingIntentSelector.php
@@ -7,9 +7,7 @@ use OpenDialogAi\AttributeEngine\CoreAttributes\UtteranceAttribute;
 use OpenDialogAi\ContextEngine\Contexts\User\UserContext;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
-use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\IntentCollection;
-use OpenDialogAi\InterpreterEngine\Facades\InterpreterService;
 
 /**
  * The TurnSelector should evaluate conditions against turns to select
@@ -20,17 +18,17 @@ class StartingIntentSelector
     public static function selectStartingIntents($turns): IntentCollection
     {
         // These are all the possible intents that could start a conversation
+        /** @var IntentCollection $intents */
         $intents = ConversationDataClient::getAllStartingIntents($turns);
 
         // Now we can pass each intent through interpreters and interpret given the utterance
         $utterance = ContextService::getAttribute(UtteranceAttribute::UTTERANCE, UserContext::USER_CONTEXT);
-        $matchingIntents = IntentInterpreterFilter::filter($conditionPassingIntents, $utterance);
+        $matchingIntents = IntentInterpreterFilter::filter($intents, $utterance);
 
         // We first reduce the set to just those that have passing conditions
-        $conditionPassingIntents = $matchingIntents->filter(function ($intent) {
-            return ConditionFilter::checkConditions($intent);
-        });
+        /** @var IntentCollection $intentsWithPassingConditions */
+        $intentsWithPassingConditions = ConditionFilter::filterObjects($matchingIntents);
 
-        return $conditionPassingIntents;
+        return $intentsWithPassingConditions;
     }
 }

--- a/src/ConversationEngine/Reasoners/TurnSelector.php
+++ b/src/ConversationEngine/Reasoners/TurnSelector.php
@@ -14,12 +14,12 @@ class TurnSelector
 {
     public static function selectStartingTurns($scenes): TurnCollection
     {
+        /** @var TurnCollection $turns */
         $turns = ConversationDataClient::getAllStartingTurns($scenes);
 
-        $conditionPassingTurns = $turns->filter(function ($turn) {
-            ConditionFilter::checkConditions($turn);
-        });
+        /** @var TurnCollection $turnsWithPassingConditions */
+        $turnsWithPassingConditions = ConditionFilter::filterObjects($turns);
 
-        return $conditionPassingTurns;
+        return $turnsWithPassingConditions;
     }
 }

--- a/src/ConversationEngine/Tests/ConditionFilterTest.php
+++ b/src/ConversationEngine/Tests/ConditionFilterTest.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace OpenDialogAi\ConversationEngine\Tests;
+
+
+use OpenDialogAi\Core\Tests\TestCase;
+
+class ConditionFilterTest extends TestCase
+{
+
+}

--- a/src/ConversationEngine/Tests/ConditionFilterTest.php
+++ b/src/ConversationEngine/Tests/ConditionFilterTest.php
@@ -4,9 +4,73 @@
 namespace OpenDialogAi\ConversationEngine\Tests;
 
 
+use OpenDialogAi\ConversationEngine\Reasoners\ConditionFilter;
+use OpenDialogAi\Core\Conversation\Condition;
+use OpenDialogAi\Core\Conversation\ConditionCollection;
+use OpenDialogAi\Core\Conversation\IntentCollection;
+use OpenDialogAi\Core\Conversation\Scene;
+use OpenDialogAi\Core\Conversation\SceneCollection;
+use OpenDialogAi\Core\Conversation\Turn;
+use OpenDialogAi\Core\Conversation\TurnCollection;
 use OpenDialogAi\Core\Tests\TestCase;
 
 class ConditionFilterTest extends TestCase
 {
+    public function testEmptyCollection()
+    {
+        $intentCollection = new IntentCollection();
 
+        $this->assertCount(0, ConditionFilter::filterObjects($intentCollection));
+    }
+
+    public function testObjectsWithNoConditions()
+    {
+        $turn1 = new Turn();
+        $turn1->setODId('test_turn1');
+
+        $turn2 = new Turn();
+        $turn2->setODId('test_turn2');
+
+        $turn3 = new Turn();
+        $turn3->setODId('test_turn3');
+
+        $turnCollection = new TurnCollection([
+            $turn1,
+            $turn2,
+            $turn3,
+        ]);
+
+        $this->assertCount(3, ConditionFilter::filterObjects($turnCollection));
+    }
+
+    public function testObjectsWithConditions()
+    {
+        $expectedScene1 = new Scene();
+        $expectedScene1->setODId('test_scene1');
+        $expectedScene1->setConditions(new ConditionCollection([
+            new Condition('eq', ['session.first_name'], ['test'])
+        ]));
+
+        $notExpectedScene = new Scene();
+        $notExpectedScene->setODId('test_scene2');
+        $notExpectedScene->setConditions(new ConditionCollection([
+            new Condition('eq', ['session.first_name'], ['unknown'])
+        ]));
+
+        $expectedScene2 = new Scene();
+        $expectedScene2->setODId('test_scene3');
+        $expectedScene2->setConditions(new ConditionCollection([
+            new Condition('eq', ['session.first_name'], ['test'])
+        ]));
+
+        $sceneCollection = new SceneCollection([
+            $expectedScene1,
+            $notExpectedScene,
+            $expectedScene2,
+        ]);
+
+        $this->assertCount(2, ConditionFilter::filterObjects($sceneCollection));
+        $this->assertContains($expectedScene1, ConditionFilter::filterObjects($sceneCollection));
+        $this->assertContains($expectedScene2, ConditionFilter::filterObjects($sceneCollection));
+    }
 }

--- a/src/ConversationEngine/Tests/ConditionFilterTest.php
+++ b/src/ConversationEngine/Tests/ConditionFilterTest.php
@@ -4,6 +4,8 @@
 namespace OpenDialogAi\ConversationEngine\Tests;
 
 
+use OpenDialogAi\ContextEngine\Contexts\BaseContexts\SessionContext;
+use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\ConversationEngine\Reasoners\ConditionFilter;
 use OpenDialogAi\Core\Conversation\Condition;
 use OpenDialogAi\Core\Conversation\ConditionCollection;
@@ -45,22 +47,24 @@ class ConditionFilterTest extends TestCase
 
     public function testObjectsWithConditions()
     {
+        ContextService::saveAttribute(SessionContext::getComponentId().".first_name", 'test');
+
         $expectedScene1 = new Scene();
         $expectedScene1->setODId('test_scene1');
         $expectedScene1->setConditions(new ConditionCollection([
-            new Condition('eq', ['session.first_name'], ['test'])
+            new Condition('eq', ['attribute' => 'session.first_name'], ['value' => 'test'])
         ]));
 
         $notExpectedScene = new Scene();
         $notExpectedScene->setODId('test_scene2');
         $notExpectedScene->setConditions(new ConditionCollection([
-            new Condition('eq', ['session.first_name'], ['unknown'])
+            new Condition('eq', ['attribute' => 'session.first_name'], ['value' => 'unknown'])
         ]));
 
         $expectedScene2 = new Scene();
         $expectedScene2->setODId('test_scene3');
         $expectedScene2->setConditions(new ConditionCollection([
-            new Condition('eq', ['session.first_name'], ['test'])
+            new Condition('eq', ['attribute' => 'session.first_name'], ['value' => 'test'])
         ]));
 
         $sceneCollection = new SceneCollection([

--- a/src/OperationEngine/BaseOperation.php
+++ b/src/OperationEngine/BaseOperation.php
@@ -3,6 +3,7 @@
 namespace OpenDialogAi\OperationEngine;
 
 use Illuminate\Support\Facades\Log;
+use OpenDialogAi\AttributeEngine\Contracts\Attribute;
 use OpenDialogAi\Core\Components\Contracts\OpenDialogComponent;
 use OpenDialogAi\Core\Components\ODComponent;
 use OpenDialogAi\Core\Components\ODComponentTypes;
@@ -26,7 +27,7 @@ abstract class BaseOperation implements OperationInterface, OpenDialogComponent
     ];
 
     /**
-     * @var \OpenDialogAi\AttributeEngine\Attributes\Attribute[]
+     * @var Attribute[]
      */
     protected $attributes;
 

--- a/src/OperationEngine/Facade/OperationService.php
+++ b/src/OperationEngine/Facade/OperationService.php
@@ -2,8 +2,17 @@
 namespace OpenDialogAi\OperationEngine\Facade;
 
 use Illuminate\Support\Facades\Facade;
+use OpenDialogAi\Core\Conversation\Condition;
+use OpenDialogAi\OperationEngine\OperationInterface;
+use OpenDialogAi\OperationEngine\Service\OperationServiceInterface;
 
-
+/**
+ * @method static array getAvailableOperations()
+ * @method static bool isOperationAvailable(string $operationName)
+ * @method static OperationInterface getOperation($operationName)
+ * @method static void registerAvailableOperations($operations)
+ * @method static bool checkCondition(Condition $condition)
+ */
 class OperationService extends Facade
 {
     /**
@@ -11,6 +20,6 @@ class OperationService extends Facade
      **/
     protected static function getFacadeAccessor()
     {
-        return \OpenDialogAi\OperationEngine\Service\OperationServiceInterface::class;
+        return OperationServiceInterface::class;
     }
 }

--- a/src/OperationEngine/Service/OperationService.php
+++ b/src/OperationEngine/Service/OperationService.php
@@ -7,8 +7,8 @@ use OpenDialogAi\AttributeEngine\Contracts\Attribute;
 use OpenDialogAi\AttributeEngine\Exceptions\AttributeDoesNotExistException;
 use OpenDialogAi\AttributeEngine\Facades\AttributeResolver;
 use OpenDialogAi\ContextEngine\ContextService\ContextParser;
-use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\ContextEngine\ContextService\ParsedAttributeName;
+use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\Core\Components\Exceptions\InvalidComponentDataException;
 use OpenDialogAi\Core\Components\Exceptions\MissingRequiredComponentDataException;
 use OpenDialogAi\Core\Conversation\Condition;
@@ -96,7 +96,7 @@ class OperationService implements OperationServiceInterface
     /**
      * @inheritDoc
      */
-    public function checkCondition(Condition $condition)
+    public function checkCondition(Condition $condition): bool
     {
         $attributes = [];
 

--- a/src/OperationEngine/Service/OperationServiceInterface.php
+++ b/src/OperationEngine/Service/OperationServiceInterface.php
@@ -37,7 +37,7 @@ interface OperationServiceInterface
 
     /**
      * @param Condition $condition
-     * @return mixed
+     * @return bool
      */
-    public function checkCondition(Condition $condition);
+    public function checkCondition(Condition $condition): bool;
 }


### PR DESCRIPTION
This PR adds the `ConditionFilter` which handles the evaluation of conditions on conversation objects. The filtering of objects by conditions has also been subsumed into the class (as it is called the condition _filter_), which has in turn made the various selector classes more succinct. 