### PR TITLE
Selectors

### DIFF
--- a/src/Conversation/Behavior.php
+++ b/src/Conversation/Behavior.php
@@ -4,6 +4,10 @@ namespace OpenDialogAi\Core\Conversation;
 
 class Behavior
 {
+    public const OPEN_BEHAVIOR = 'open';
+    public const STARTING_BEHAVIOR = 'starting';
+    public const COMPLETING_BEHAVIOR = 'completing';
+
     protected string $behaviour;
 
     public function __construct(string $behavior)

--- a/src/Conversation/ConversationObject.php
+++ b/src/Conversation/ConversationObject.php
@@ -141,6 +141,15 @@ class ConversationObject
     }
 
     /**
+     * @param ConditionCollection $conditions
+     * @return void
+     */
+    public function setConditions(ConditionCollection $conditions): void
+    {
+        $this->conditions = $conditions;
+    }
+
+    /**
      * Indicates whether an object is associates with behaviors.
      * @return bool
      */

--- a/src/Conversation/ConversationObject.php
+++ b/src/Conversation/ConversationObject.php
@@ -164,11 +164,19 @@ class ConversationObject
 
     /**
      * Retrieves all behavior directives as an array.
-     * @return array
+     * @return BehaviorsCollection
      */
     public function getBehaviors(): BehaviorsCollection
     {
         return $this->behaviors;
+    }
+
+    /**
+     * @param BehaviorsCollection $behaviors
+     */
+    public function setBehaviors(BehaviorsCollection $behaviors): void
+    {
+        $this->behaviors = $behaviors;
     }
 
     /**

--- a/src/Conversation/DataClients/ConversationDataClient.php
+++ b/src/Conversation/DataClients/ConversationDataClient.php
@@ -6,7 +6,6 @@ namespace OpenDialogAi\Core\Conversation\DataClients;
 use Illuminate\Support\Facades\Http;
 use OpenDialogAi\Core\Conversation\ConversationCollection;
 use OpenDialogAi\Core\Conversation\IntentCollection;
-use OpenDialogAi\Core\Conversation\Scenario;
 use OpenDialogAi\Core\Conversation\ScenarioCollection;
 use OpenDialogAi\Core\Conversation\SceneCollection;
 use OpenDialogAi\Core\Conversation\TurnCollection;
@@ -54,57 +53,170 @@ query Scenarios {
 
     /**
      * Retrieve all scenarios where active is set to true and their status is live
-     * @todo handle returning scenarios that are in preview mode (or do we use an OD condition for that)
+     * @param bool $shallow
      * @return ScenarioCollection
+     * @todo handle returning scenarios that are in preview mode (or do we use an OD condition for that)
      */
-    public function getAllActiveScenarios(): ScenarioCollection
+    public function getAllActiveScenarios(bool $shallow): ScenarioCollection
     {
         return new ScenarioCollection();
     }
 
     /**
-     * Retrieve all conversations from within the scenario collection that have a behavior as "starting".
+     * Retrieve all conversations that belong to the given scenarios that have a behavior as "starting". from the graph
+     *
+     * @param ScenarioCollection $scenarios
+     * @param bool $shallow
      * @return ConversationCollection
      */
-    public function getAllStartingConversations(ScenarioCollection $scenarios): ConversationCollection
+    public function getAllStartingConversations(ScenarioCollection $scenarios, bool $shallow): ConversationCollection
     {
         return new ConversationCollection();
     }
 
     /**
-     * Retrieve all scenes from within the conversation collection that have a behavior as "starting"
+     * Retrieve all conversations that belong to the given scenarios that have a behavior as "open". from the graph
+     *
+     * @param ScenarioCollection $scenarios
+     * @param bool $shallow
+     * @return ConversationCollection
+     */
+    public function getAllOpenConversations(ScenarioCollection $scenarios, bool $shallow): ConversationCollection
+    {
+        return new ConversationCollection();
+    }
+
+    /**
+     * Retrieve all conversations that belong to the given scenarios. from the graph
+     *
+     * @param ScenarioCollection $scenarios
+     * @param bool $shallow
+     * @return ConversationCollection
+     */
+    public function getAllConversations(ScenarioCollection $scenarios, bool $shallow): ConversationCollection
+    {
+        return new ConversationCollection();
+    }
+
+    /**
+     * Retrieve all scenes that belong to the given conversations that have a behavior as "starting" from the graph
+     *
      * @param ConversationCollection $conversations
+     * @param bool $shallow
      * @return SceneCollection
      */
-    public function getAllStartingScenes(ConversationCollection $conversations): SceneCollection
+    public function getAllStartingScenes(ConversationCollection $conversations, bool $shallow): SceneCollection
     {
         return new SceneCollection();
     }
 
     /**
+     * Retrieve all scenes that belong to the given conversations that have a behavior as "open" from the graph
+     *
+     * @param ConversationCollection $conversations
+     * @param bool $shallow
+     * @return SceneCollection
+     */
+    public function getAllOpenScenes(ConversationCollection $conversations, bool $shallow): SceneCollection
+    {
+        return new SceneCollection();
+    }
+
+    /**
+     * Retrieve all scenes that belong to the given conversations from the graph
+     *
+     * @param ConversationCollection $conversations
+     * @param bool $shallow
+     * @return SceneCollection
+     */
+    public function getAllScenes(ConversationCollection $conversations, bool $shallow): SceneCollection
+    {
+        return new SceneCollection();
+    }
+
+    /**
+     * Retrieve all scenes that belong to the given conversations that have a behavior as "starting" from the graph
+     *
      * @param SceneCollection $scenes
+     * @param bool $shallow
      * @return TurnCollection
      */
-    public function getAllStartingTurns(SceneCollection $scenes): TurnCollection
+    public function getAllStartingTurns(SceneCollection $scenes, bool $shallow): TurnCollection
     {
         return new TurnCollection();
     }
 
     /**
-     * @param TurnCollection $turns
+     * Retrieve all scenes that belong to the given conversations that have a behavior as "open" from the graph
+     *
+     * @param SceneCollection $scenes
+     * @param bool $shallow
      * @return TurnCollection
      */
-    public function getAllStartingIntents(TurnCollection $turns): IntentCollection
+    public function getAllOpenTurns(SceneCollection $scenes, bool $shallow): TurnCollection
+    {
+        return new TurnCollection();
+    }
+
+    /**
+     * Retrieve all scenes that belong to the given conversations from the graph
+     *
+     * @param SceneCollection $scenes
+     * @param bool $shallow
+     * @return TurnCollection
+     */
+    public function getAllTurns(SceneCollection $scenes, bool $shallow): TurnCollection
+    {
+        return new TurnCollection();
+    }
+
+    /**
+     * Retrieve all request intents that belong to the given turns from the graph
+     *
+     * @param TurnCollection $turns
+     * @param bool $shallow
+     * @return IntentCollection
+     */
+    public function getAllRequestIntents(TurnCollection $turns, bool $shallow): IntentCollection
     {
         return new IntentCollection();
     }
 
     /**
-     * @param $scenario_id
-     * @return Scenario
+     * Retrieve all response intents that belong to the given turns from the graph
+     *
+     * @param TurnCollection $turns
+     * @param bool $shallow
+     * @return IntentCollection
      */
-    public function getShallowScenario($scenario_id): Scenario
+    public function getAllResponseIntents(TurnCollection $turns, bool $shallow): IntentCollection
     {
-        return new Scenario();
+        return new IntentCollection();
+    }
+
+    /**
+     * Retrieve all request intents with the given ID that belong to the given turns from the graph
+     *
+     * @param TurnCollection $turns
+     * @param string $intentId
+     * @param bool $shallow
+     * @return IntentCollection
+     */
+    public function getAllRequestIntentsById(TurnCollection $turns, string $intentId, bool $shallow): IntentCollection
+    {
+        return new IntentCollection();
+    }
+
+    /**
+     * Retrieve all response intents with the given ID that belong to the given turns from the graph
+     *
+     * @param TurnCollection $turns
+     * @param string $intentId
+     * @param bool $shallow
+     * @return IntentCollection
+     */
+    public function getAllResponseIntentsById(TurnCollection $turns, string $intentId, bool $shallow): IntentCollection
+    {
+        return new IntentCollection();
     }
 }

--- a/src/Conversation/Facades/ConversationDataClient.php
+++ b/src/Conversation/Facades/ConversationDataClient.php
@@ -2,17 +2,30 @@
 namespace OpenDialogAi\Core\Conversation\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use OpenDialogAi\Core\Conversation\ConversationCollection;
+use OpenDialogAi\Core\Conversation\IntentCollection;
+use OpenDialogAi\Core\Conversation\ScenarioCollection;
+use OpenDialogAi\Core\Conversation\SceneCollection;
+use OpenDialogAi\Core\Conversation\TurnCollection;
 
+/**
+ * @method static ScenarioCollection getAllActiveScenarios(bool $shallow)
+ * @method static ConversationCollection getAllStartingConversations(ScenarioCollection $scenarios, bool $shallow)
+ * @method static ConversationCollection getAllOpenConversations(ScenarioCollection $scenarios, bool $shallow)
+ * @method static ConversationCollection getAllConversations(ScenarioCollection $scenarios, bool $shallow)
+ * @method static SceneCollection getAllStartingScenes(ConversationCollection $conversations, bool $shallow)
+ * @method static SceneCollection getAllOpenScenes(ConversationCollection $conversations, bool $shallow)
+ * @method static SceneCollection getAllScenes(ConversationCollection $conversations, bool $shallow)
+ * @method static TurnCollection getAllStartingTurns(SceneCollection $scenes, bool $shallow)
+ * @method static TurnCollection getAllOpenTurns(SceneCollection $scenes, bool $shallow)
+ * @method static TurnCollection getAllTurns(SceneCollection $scenes, bool $shallow)
+ * @method static IntentCollection getAllRequestIntents(TurnCollection $turns, bool $shallow)
+ * @method static IntentCollection getAllResponseIntents(TurnCollection $turns, bool $shallow)
+ * @method static IntentCollection getAllRequestIntentsById(TurnCollection $turns, string $intentId, bool $shallow)
+ * @method static IntentCollection getAllResponseIntentsById(TurnCollection $turns, string $intentId, bool $shallow)
+ **/
 class ConversationDataClient extends Facade
 {
-    /**
-     * @method static function getAllActiveScenarios(): ScenarioCollection
-     * @method static function getAllStartingConversations(ScenarioCollection $scenarios): ConversationCollection
-     * @method static function getAllStartingScenes(ConversationCollection $conversations): SceneCollection
-     * @method static function getAllStartingTurns(SceneCollection $scenes): TurnCollection
-     * @method static function getAllStartingIntents(TurnCollection $turns) IntentCollection
-     * @method static function getShallowScenario($scenario_id): Scenario
-     **/
     protected static function getFacadeAccessor()
     {
         return \OpenDialogAi\Core\Conversation\DataClients\ConversationDataClient::class;

--- a/src/Conversation/Scenario.php
+++ b/src/Conversation/Scenario.php
@@ -24,6 +24,11 @@ class Scenario extends ConversationObject
         return $this->conversations;
     }
 
+    public function setConversations(ConversationCollection $conversations)
+    {
+        $this->conversations = $conversations;
+    }
+
     public function addConversation(Conversation $conversation)
     {
         $this->conversations->addObject($conversation);

--- a/src/Conversation/Tests/ConversationGenerator.php
+++ b/src/Conversation/Tests/ConversationGenerator.php
@@ -4,6 +4,7 @@
 namespace OpenDialogAi\Core\Conversation\Tests;
 
 
+use OpenDialogAi\Core\Conversation\ConditionCollection;
 use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\Scenario;
@@ -50,59 +51,84 @@ class ConversationGenerator
         return $scenarios;
     }
 
-    public static function createScenario($odId)
+    public static function createScenario($odId, ?ConditionCollection $conditions = null): Scenario
     {
         $scenario = new Scenario();
         $scenario->setODId($odId);
         $scenario->setName($odId);
         $scenario->setDescription("This is a scenario called ". $odId);
+
+        if (!is_null($conditions)) {
+            $scenario->setConditions($conditions);
+        }
+
         return $scenario;
     }
 
-    public static function createConversation($odId): Conversation
+    public static function createConversation($odId, ?ConditionCollection $conditions = null): Conversation
     {
         $conversation = new Conversation();
         $conversation->setODId($odId);
         $conversation->setName($odId);
         $conversation->setDescription("This is a conversation for " . $odId);
 
+        if (!is_null($conditions)) {
+            $conversation->setConditions($conditions);
+        }
+
         return $conversation;
     }
 
-    public static function createScene($odId): Scene
+    public static function createScene($odId, ?ConditionCollection $conditions = null): Scene
     {
         $scene = new Scene();
         $scene->setODId($odId);
         $scene->setName($odId);
         $scene->setDescription("This is a scene for " . $odId);
 
+        if (!is_null($conditions)) {
+            $scene->setConditions($conditions);
+        }
+
         return $scene;
     }
 
-    public static function createTurn($odId): Turn
+    public static function createTurn($odId, ?ConditionCollection $conditions = null): Turn
     {
         $turn = new Turn();
         $turn->setODId($odId);
         $turn->setName($odId);
         $turn->setDescription("This is a turn for test purposes");
 
+        if (!is_null($conditions)) {
+            $turn->setConditions($conditions);
+        }
+
         return $turn;
     }
 
-    public static function createUserIntent($odId): Intent
+    public static function createUserIntent($odId, ?ConditionCollection $conditions = null): Intent
     {
         $intent = new Intent();
         $intent->setODId($odId);
         $intent->setSpeaker(Intent::USER);
 
+        if (!is_null($conditions)) {
+            $intent->setConditions($conditions);
+        }
+
         return $intent;
     }
 
-    public static function createAppIntent($odId): Intent
+    public static function createAppIntent($odId, ?ConditionCollection $conditions = null): Intent
     {
         $intent = new Intent();
         $intent->setODId($odId);
         $intent->setSpeaker(Intent::APP);
+
+        if (!is_null($conditions)) {
+            $intent->setConditions($conditions);
+        }
 
         return $intent;
     }

--- a/src/Conversation/Tests/ConversationGenerator.php
+++ b/src/Conversation/Tests/ConversationGenerator.php
@@ -112,6 +112,7 @@ class ConversationGenerator
         $intent = new Intent();
         $intent->setODId($odId);
         $intent->setSpeaker(Intent::USER);
+        $intent->setConfidence(1);
 
         if (!is_null($conditions)) {
             $intent->setConditions($conditions);
@@ -125,6 +126,7 @@ class ConversationGenerator
         $intent = new Intent();
         $intent->setODId($odId);
         $intent->setSpeaker(Intent::APP);
+        $intent->setConfidence(1);
 
         if (!is_null($conditions)) {
             $intent->setConditions($conditions);

--- a/src/ConversationEngine/Exceptions/EmptyCollectionException.php
+++ b/src/ConversationEngine/Exceptions/EmptyCollectionException.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace OpenDialogAi\ConversationEngine\Exceptions;
+
+
+use Exception;
+
+class EmptyCollectionException extends Exception
+{
+
+}

--- a/src/ConversationEngine/Reasoners/ConditionFilter.php
+++ b/src/ConversationEngine/Reasoners/ConditionFilter.php
@@ -4,26 +4,68 @@
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
 
+use OpenDialogAi\Core\Conversation\Condition;
+use OpenDialogAi\Core\Conversation\ConditionCollection;
 use OpenDialogAi\Core\Conversation\ConversationObject;
+use OpenDialogAi\Core\Conversation\ODObjectCollection;
 use OpenDialogAi\OperationEngine\Facade\OperationService;
 
 class ConditionFilter
 {
-    public static function checkConditions(ConversationObject $object): bool
+    /**
+     * @param ODObjectCollection $objects
+     * @return ODObjectCollection
+     */
+    public static function filterObjects(ODObjectCollection $objects): ODObjectCollection
     {
-        $conditions = $object->getConditions();
-        // Check each condition in turn to see if it passes
-        $passingConditions = $conditions->filter(function ($condition) {
-            if (OperationService::checkCondition($condition)) {
-                return true;
-            }
-            return false;
+        return $objects->filter(function (ConversationObject $object) {
+            return self::checkConditionsForObject($object);
         });
-        //If all the conditions passed we return true
-        if (count($passingConditions) == count ($conditions)) {
-            return true;
-        }
+    }
 
-        return false;
+    /**
+     * Returns whether the conditions for the given object all passed
+     *
+     * @param ConversationObject $object
+     * @return bool
+     */
+    public static function checkConditionsForObject(ConversationObject $object): bool
+    {
+        return self::checkConditions($object->getConditions());
+    }
+
+    /**
+     * Returns whether the conditions all passed
+     *
+     * @param ConditionCollection $conditions
+     * @return bool
+     */
+    public static function checkConditions(ConditionCollection $conditions): bool
+    {
+        $allConditionsPassed = true;
+
+        $conditions->each(function (Condition $condition) use (&$allConditionsPassed) {
+            $conditionPassed = self::checkCondition($condition);
+
+            if (!$conditionPassed) {
+                $allConditionsPassed = false;
+            }
+
+            // Will break when this returns false
+            return $conditionPassed;
+        });
+
+        return $allConditionsPassed;
+    }
+
+    /**
+     * Returns whether the condition passed
+     *
+     * @param Condition $condition
+     * @return bool
+     */
+    public static function checkCondition(Condition $condition): bool
+    {
+        return OperationService::checkCondition($condition);
     }
 }

--- a/src/ConversationEngine/Reasoners/ConversationSelector.php
+++ b/src/ConversationEngine/Reasoners/ConversationSelector.php
@@ -3,6 +3,8 @@
 
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
+use OpenDialogAi\ConversationEngine\Exceptions\EmptyCollectionException;
+use OpenDialogAi\ConversationEngine\Util\SelectorUtil;
 use OpenDialogAi\Core\Conversation\ConversationCollection;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\ScenarioCollection;
@@ -18,13 +20,15 @@ class ConversationSelector
      * @param ScenarioCollection $scenarios
      * @param bool $shallow
      * @return ConversationCollection
+     * @throws EmptyCollectionException
      */
     public static function selectStartingConversations(
         ScenarioCollection $scenarios,
         bool $shallow = true
     ): ConversationCollection {
-        /** @var ConversationCollection $conversations */
-        $conversations = ConversationDataClient::getAllStartingConversations($scenarios);
+        SelectorUtil::throwIfConversationObjectCollectionIsEmpty($scenarios);
+
+        $conversations = ConversationDataClient::getAllStartingConversations($scenarios, $shallow);
 
         /** @var ConversationCollection $conversationsWithPassingConditions */
         $conversationsWithPassingConditions = ConditionFilter::filterObjects($conversations);
@@ -38,12 +42,20 @@ class ConversationSelector
      * @param ScenarioCollection $scenarios
      * @param bool $shallow
      * @return ConversationCollection
+     * @throws EmptyCollectionException
      */
     public static function selectOpenConversations(
         ScenarioCollection $scenarios,
         bool $shallow = true
     ): ConversationCollection {
-        return new ConversationCollection();
+        SelectorUtil::throwIfConversationObjectCollectionIsEmpty($scenarios);
+
+        $conversations = ConversationDataClient::getAllOpenConversations($scenarios, $shallow);
+
+        /** @var ConversationCollection $conversationsWithPassingConditions */
+        $conversationsWithPassingConditions = ConditionFilter::filterObjects($conversations);
+
+        return $conversationsWithPassingConditions;
     }
 
     /**
@@ -52,9 +64,17 @@ class ConversationSelector
      * @param ScenarioCollection $scenarios
      * @param bool $shallow
      * @return ConversationCollection
+     * @throws EmptyCollectionException
      */
     public static function selectConversations(ScenarioCollection $scenarios, bool $shallow = true): ConversationCollection
     {
-        return new ConversationCollection();
+        SelectorUtil::throwIfConversationObjectCollectionIsEmpty($scenarios);
+
+        $conversations = ConversationDataClient::getAllConversations($scenarios, $shallow);
+
+        /** @var ConversationCollection $conversationsWithPassingConditions */
+        $conversationsWithPassingConditions = ConditionFilter::filterObjects($conversations);
+
+        return $conversationsWithPassingConditions;
     }
 }

--- a/src/ConversationEngine/Reasoners/ConversationSelector.php
+++ b/src/ConversationEngine/Reasoners/ConversationSelector.php
@@ -15,13 +15,13 @@ class ConversationSelector
 {
     public static function selectStartingConversations(ScenarioCollection $scenarios): ConversationCollection
     {
+        /** @var ConversationCollection $conversations */
         $conversations = ConversationDataClient::getAllStartingConversations($scenarios);
 
-        $conditionPassingConversations = $conversations->filter(function ($conversation) {
-            ConditionFilter::checkConditions($conversation);
-        });
+        /** @var ConversationCollection $conversationsWithPassingConditions */
+        $conversationsWithPassingConditions = ConditionFilter::filterObjects($conversations);
 
-        return $conditionPassingConversations;
+        return $conversationsWithPassingConditions;
     }
 
 }

--- a/src/ConversationEngine/Reasoners/ConversationSelector.php
+++ b/src/ConversationEngine/Reasoners/ConversationSelector.php
@@ -8,13 +8,21 @@ use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\ScenarioCollection;
 
 /**
- * The ConversationSelector should evaluate conditions against conversations to select
- * which scenarios can validly be considered for the current user
+ * This selector provides methods that select various types of conversations and filters them by evaluating their conditions
  */
 class ConversationSelector
 {
-    public static function selectStartingConversations(ScenarioCollection $scenarios): ConversationCollection
-    {
+    /**
+     * Retrieves all conversations that have the starting behaviour, within the given scenarios
+     *
+     * @param ScenarioCollection $scenarios
+     * @param bool $shallow
+     * @return ConversationCollection
+     */
+    public static function selectStartingConversations(
+        ScenarioCollection $scenarios,
+        bool $shallow = true
+    ): ConversationCollection {
         /** @var ConversationCollection $conversations */
         $conversations = ConversationDataClient::getAllStartingConversations($scenarios);
 
@@ -24,4 +32,29 @@ class ConversationSelector
         return $conversationsWithPassingConditions;
     }
 
+    /**
+     * Retrieves all conversations that have the open behaviour, within the given scenarios
+     *
+     * @param ScenarioCollection $scenarios
+     * @param bool $shallow
+     * @return ConversationCollection
+     */
+    public static function selectOpenConversations(
+        ScenarioCollection $scenarios,
+        bool $shallow = true
+    ): ConversationCollection {
+        return new ConversationCollection();
+    }
+
+    /**
+     * Retrieves all conversations within the given scenarios
+     *
+     * @param ScenarioCollection $scenarios
+     * @param bool $shallow
+     * @return ConversationCollection
+     */
+    public static function selectConversations(ScenarioCollection $scenarios, bool $shallow = true): ConversationCollection
+    {
+        return new ConversationCollection();
+    }
 }

--- a/src/ConversationEngine/Reasoners/IntentInterpreterFilter.php
+++ b/src/ConversationEngine/Reasoners/IntentInterpreterFilter.php
@@ -15,19 +15,20 @@ class IntentInterpreterFilter
         $interpretedIntents = $intents->map(function (Intent $intent) use ($utterance) {
             // Get the interpreter defined in the current model
             $interpreter = $intent->getInterpreter();
-            $interpretedIntents = new IntentCollection();
 
             if ($interpreter) {
                 $interpretations = InterpreterService::interpret($intent->getInterpreter(), $utterance);
             } else {
                 $interpretations = InterpreterService::interpretDefaultInterpreter($utterance);
             }
+
             $intent->addInterpretedIntents($interpretations);
+
             return $intent;
         });
 
         // With the interpretations in place let us do a match
-        $matchingIntents = $interpretedIntents->filter(function ($intent) {
+        $matchingIntents = $interpretedIntents->filter(function (Intent $intent) {
             return $intent->checkForMatch();
         });
 

--- a/src/ConversationEngine/Reasoners/IntentSelector.php
+++ b/src/ConversationEngine/Reasoners/IntentSelector.php
@@ -7,15 +7,13 @@ use OpenDialogAi\AttributeEngine\CoreAttributes\UtteranceAttribute;
 use OpenDialogAi\ContextEngine\Contexts\User\UserContext;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
-use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\IntentCollection;
-use OpenDialogAi\InterpreterEngine\Facades\InterpreterService;
 
 /**
  * The TurnSelector should evaluate conditions against turns to select
  * which turns can validly be considered for a user
  */
-class StartingIntentSelector
+class IntentSelector
 {
     public static function selectStartingIntents($turns): IntentCollection
     {

--- a/src/ConversationEngine/Reasoners/IntentSelector.php
+++ b/src/ConversationEngine/Reasoners/IntentSelector.php
@@ -8,23 +8,25 @@ use OpenDialogAi\ContextEngine\Contexts\User\UserContext;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\IntentCollection;
+use OpenDialogAi\Core\Conversation\TurnCollection;
 
 /**
- * The TurnSelector should evaluate conditions against turns to select
- * which turns can validly be considered for a user
+ * This selector provides methods that select various types of intents and filters them by evaluating their conditions
  */
 class IntentSelector
 {
     /**
-     * @param $turns
+     * Retrieves all request intents within the given turns
+     *
+     * @param TurnCollection $turns
      * @param bool $shallow
      * @return IntentCollection
      */
-    public static function selectStartingIntents($turns, bool $shallow = true): IntentCollection
+    public static function selectRequestIntents(TurnCollection $turns, bool $shallow = true): IntentCollection
     {
         // These are all the possible intents that could start a conversation
         /** @var IntentCollection $intents */
-        $intents = ConversationDataClient::getAllStartingIntents($turns);
+        $intents = ConversationDataClient::getAllRequestIntents($turns);
 
         // Now we can pass each intent through interpreters and interpret given the utterance
         $utterance = ContextService::getAttribute(UtteranceAttribute::UTTERANCE, UserContext::USER_CONTEXT);
@@ -35,5 +37,49 @@ class IntentSelector
         $intentsWithPassingConditions = ConditionFilter::filterObjects($matchingIntents);
 
         return $intentsWithPassingConditions;
+    }
+
+    /**
+     * Retrieves all response intents within the given turns
+     *
+     * @param TurnCollection $turns
+     * @param bool $shallow
+     * @return IntentCollection
+     */
+    public static function selectResponseIntents(TurnCollection $turns, bool $shallow = true): IntentCollection
+    {
+        return new IntentCollection();
+    }
+
+    /**
+     * Retrieves all request intents that match the given intent ID, within the given turns
+     *
+     * @param TurnCollection $turns
+     * @param string $intentId
+     * @param bool $shallow
+     * @return IntentCollection
+     */
+    public static function selectRequestIntentsById(
+        TurnCollection $turns,
+        string $intentId,
+        bool $shallow = true
+    ): IntentCollection {
+        return new IntentCollection();
+    }
+
+    /**
+     * Retrieves all response intents that match the given intent ID, within the given turns
+     *
+     * @param TurnCollection $turns
+     * @param string $intentId
+     * @param bool $shallow
+     * @return IntentCollection
+     */
+    public static function selectResponseIntentsById(
+        TurnCollection $turns,
+        string $intentId,
+        bool $shallow = true
+    ): IntentCollection {
+        return new IntentCollection();
     }
 }

--- a/src/ConversationEngine/Reasoners/IntentSelector.php
+++ b/src/ConversationEngine/Reasoners/IntentSelector.php
@@ -15,7 +15,12 @@ use OpenDialogAi\Core\Conversation\IntentCollection;
  */
 class IntentSelector
 {
-    public static function selectStartingIntents($turns): IntentCollection
+    /**
+     * @param $turns
+     * @param bool $shallow
+     * @return IntentCollection
+     */
+    public static function selectStartingIntents($turns, bool $shallow = true): IntentCollection
     {
         // These are all the possible intents that could start a conversation
         /** @var IntentCollection $intents */

--- a/src/ConversationEngine/Reasoners/IntentSelector.php
+++ b/src/ConversationEngine/Reasoners/IntentSelector.php
@@ -18,17 +18,17 @@ class IntentSelector
     public static function selectStartingIntents($turns): IntentCollection
     {
         // These are all the possible intents that could start a conversation
+        /** @var IntentCollection $intents */
         $intents = ConversationDataClient::getAllStartingIntents($turns);
 
         // Now we can pass each intent through interpreters and interpret given the utterance
         $utterance = ContextService::getAttribute(UtteranceAttribute::UTTERANCE, UserContext::USER_CONTEXT);
-        $matchingIntents = IntentInterpreterFilter::filter($conditionPassingIntents, $utterance);
+        $matchingIntents = IntentInterpreterFilter::filter($intents, $utterance);
 
         // We first reduce the set to just those that have passing conditions
-        $conditionPassingIntents = $matchingIntents->filter(function ($intent) {
-            return ConditionFilter::checkConditions($intent);
-        });
+        /** @var IntentCollection $intentsWithPassingConditions */
+        $intentsWithPassingConditions = ConditionFilter::filterObjects($matchingIntents);
 
-        return $conditionPassingIntents;
+        return $intentsWithPassingConditions;
     }
 }

--- a/src/ConversationEngine/Reasoners/OpeningIntentSelectorStrategy.php
+++ b/src/ConversationEngine/Reasoners/OpeningIntentSelectorStrategy.php
@@ -25,7 +25,7 @@ class OpeningIntentSelectorStrategy
         if ($current_scenario_id == Scenario::UNDEFINED) {
             // Select valid scenarios based on whether they have passing conditions
             /* @var ScenarioCollection $scenarios */
-            $scenarios = ScenarioSelector::selectActiveScenarios();
+            $scenarios = ScenarioSelector::selectScenarios(true);
         } else {
             $scenario = ConversationDataClient::getShallowScenario($current_scenario_id);
             $scenarios->addObject($scenario);

--- a/src/ConversationEngine/Reasoners/OpeningIntentSelectorStrategy.php
+++ b/src/ConversationEngine/Reasoners/OpeningIntentSelectorStrategy.php
@@ -44,7 +44,7 @@ class OpeningIntentSelectorStrategy
 
         // Select valid intents out of the valid turns. Valid intents will match the interpretation and have passing
         // conditions.
-        $intents = IntentSelector::selectStartingIntents($turns);
+        $intents = IntentSelector::selectRequestIntents($turns);
 
         // Finally out of all the matching intents select the one with the highest confidence.
         /* @var Intent $intent */

--- a/src/ConversationEngine/Reasoners/OpeningIntentSelectorStrategy.php
+++ b/src/ConversationEngine/Reasoners/OpeningIntentSelectorStrategy.php
@@ -3,17 +3,12 @@
 
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
-use OpenDialogAi\ContextEngine\Exceptions\ScopeNotSetException;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\ConversationEngine\ConversationEngine;
-use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\Intent;
-use OpenDialogAi\Core\Conversation\IntentCollection;
 use OpenDialogAi\Core\Conversation\Scenario;
 use OpenDialogAi\Core\Conversation\ScenarioCollection;
-use OpenDialogAi\Core\Conversation\Scene;
-use OpenDialogAi\Core\Conversation\Turn;
 
 /**
  * The OpeningIntentSelector drills down from Scenarios to Intents to find an appropriate opening
@@ -49,7 +44,7 @@ class OpeningIntentSelectorStrategy
 
         // Select valid intents out of the valid turns. Valid intents will match the interpretation and have passing
         // conditions.
-        $intents = StartingIntentSelector::selectStartingIntents($turns);
+        $intents = IntentSelector::selectStartingIntents($turns);
 
         // Finally out of all the matching intents select the one with the highest confidence.
         /* @var Intent $intent */

--- a/src/ConversationEngine/Reasoners/ScenarioSelector.php
+++ b/src/ConversationEngine/Reasoners/ScenarioSelector.php
@@ -13,13 +13,14 @@ use OpenDialogAi\Core\Conversation\ScenarioCollection;
 class ScenarioSelector
 {
     /**
+     * Retrieves all scenarios
+     *
      * @param bool $shallow
      * @return ScenarioCollection
      */
     public static function selectScenarios(bool $shallow = true): ScenarioCollection
     {
-        /** @var ScenarioCollection $scenarios */
-        $scenarios = ConversationDataClient::getAllActiveScenarios();
+        $scenarios = ConversationDataClient::getAllActiveScenarios($shallow);
 
         /** @var ScenarioCollection $scenariosWithPassingConditions */
         $scenariosWithPassingConditions = ConditionFilter::filterObjects($scenarios);

--- a/src/ConversationEngine/Reasoners/ScenarioSelector.php
+++ b/src/ConversationEngine/Reasoners/ScenarioSelector.php
@@ -12,7 +12,11 @@ use OpenDialogAi\Core\Conversation\ScenarioCollection;
  */
 class ScenarioSelector
 {
-    public static function selectActiveScenarios(): ScenarioCollection
+    /**
+     * @param bool $shallow
+     * @return ScenarioCollection
+     */
+    public static function selectScenarios(bool $shallow = true): ScenarioCollection
     {
         /** @var ScenarioCollection $scenarios */
         $scenarios = ConversationDataClient::getAllActiveScenarios();

--- a/src/ConversationEngine/Reasoners/ScenarioSelector.php
+++ b/src/ConversationEngine/Reasoners/ScenarioSelector.php
@@ -4,7 +4,6 @@
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
-use OpenDialogAi\Core\Conversation\Scenario;
 use OpenDialogAi\Core\Conversation\ScenarioCollection;
 
 /**
@@ -15,12 +14,13 @@ class ScenarioSelector
 {
     public static function selectActiveScenarios(): ScenarioCollection
     {
+        /** @var ScenarioCollection $scenarios */
         $scenarios = ConversationDataClient::getAllActiveScenarios();
 
-        $conditionPassingScenarios = $scenarios->filter(function ($scenario) {
-            return ConditionFilter::checkConditions($scenario);
-        });
-        return $conditionPassingScenarios;
+        /** @var ScenarioCollection $scenariosWithPassingConditions */
+        $scenariosWithPassingConditions = ConditionFilter::filterObjects($scenarios);
+
+        return $scenariosWithPassingConditions;
     }
 
 }

--- a/src/ConversationEngine/Reasoners/SceneSelector.php
+++ b/src/ConversationEngine/Reasoners/SceneSelector.php
@@ -3,16 +3,23 @@
 
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
+use OpenDialogAi\Core\Conversation\ConversationCollection;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\SceneCollection;
 
 /**
- * The SceneSelector should evaluate conditions against scenes to select
- * which scenes can validly be considered for a user
+ * This selector provides methods that select various types of scenes and filters them by evaluating their conditions
  */
 class SceneSelector
 {
-    public static function selectStartingScenes($conversations): SceneCollection
+    /**
+     * Retrieves all scenes that have the starting behaviour, within the given conversations
+     *
+     * @param ConversationCollection $conversations
+     * @param bool $shallow
+     * @return SceneCollection
+     */
+    public static function selectStartingScenes(ConversationCollection $conversations, bool $shallow = true): SceneCollection
     {
         /** @var SceneCollection $scenes */
         $scenes = ConversationDataClient::getAllStartingScenes($conversations);
@@ -21,5 +28,29 @@ class SceneSelector
         $scenesWithPassingConditions = ConditionFilter::filterObjects($scenes);
 
         return $scenesWithPassingConditions;
+    }
+
+    /**
+     * Retrieves all scenes that have the open behaviour, within the given conversations
+     *
+     * @param ConversationCollection $conversations
+     * @param bool $shallow
+     * @return SceneCollection
+     */
+    public static function selectOpenScenes(ConversationCollection $conversations, bool $shallow = true): SceneCollection
+    {
+        return new SceneCollection();
+    }
+
+    /**
+     * Retrieves all scenes within the given conversations
+     *
+     * @param ConversationCollection $conversations
+     * @param bool $shallow
+     * @return SceneCollection
+     */
+    public static function selectScenes(ConversationCollection $conversations, bool $shallow = true): SceneCollection
+    {
+        return new SceneCollection();
     }
 }

--- a/src/ConversationEngine/Reasoners/SceneSelector.php
+++ b/src/ConversationEngine/Reasoners/SceneSelector.php
@@ -14,12 +14,12 @@ class SceneSelector
 {
     public static function selectStartingScenes($conversations): SceneCollection
     {
+        /** @var SceneCollection $scenes */
         $scenes = ConversationDataClient::getAllStartingScenes($conversations);
 
-        $conditionPassingScenes = $scenes->filter(function ($scene) {
-            ConditionFilter::checkConditions($scene);
-        });
+        /** @var SceneCollection $scenesWithPassingConditions */
+        $scenesWithPassingConditions = ConditionFilter::filterObjects($scenes);
 
-        return $conditionPassingScenes;
+        return $scenesWithPassingConditions;
     }
 }

--- a/src/ConversationEngine/Reasoners/SceneSelector.php
+++ b/src/ConversationEngine/Reasoners/SceneSelector.php
@@ -3,6 +3,8 @@
 
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
+use OpenDialogAi\ConversationEngine\Exceptions\EmptyCollectionException;
+use OpenDialogAi\ConversationEngine\Util\SelectorUtil;
 use OpenDialogAi\Core\Conversation\ConversationCollection;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\SceneCollection;
@@ -18,11 +20,13 @@ class SceneSelector
      * @param ConversationCollection $conversations
      * @param bool $shallow
      * @return SceneCollection
+     * @throws EmptyCollectionException
      */
     public static function selectStartingScenes(ConversationCollection $conversations, bool $shallow = true): SceneCollection
     {
-        /** @var SceneCollection $scenes */
-        $scenes = ConversationDataClient::getAllStartingScenes($conversations);
+        SelectorUtil::throwIfConversationObjectCollectionIsEmpty($conversations);
+
+        $scenes = ConversationDataClient::getAllStartingScenes($conversations, $shallow);
 
         /** @var SceneCollection $scenesWithPassingConditions */
         $scenesWithPassingConditions = ConditionFilter::filterObjects($scenes);
@@ -36,10 +40,18 @@ class SceneSelector
      * @param ConversationCollection $conversations
      * @param bool $shallow
      * @return SceneCollection
+     * @throws EmptyCollectionException
      */
     public static function selectOpenScenes(ConversationCollection $conversations, bool $shallow = true): SceneCollection
     {
-        return new SceneCollection();
+        SelectorUtil::throwIfConversationObjectCollectionIsEmpty($conversations);
+
+        $scenes = ConversationDataClient::getAllOpenScenes($conversations, $shallow);
+
+        /** @var SceneCollection $scenesWithPassingConditions */
+        $scenesWithPassingConditions = ConditionFilter::filterObjects($scenes);
+
+        return $scenesWithPassingConditions;
     }
 
     /**
@@ -48,9 +60,17 @@ class SceneSelector
      * @param ConversationCollection $conversations
      * @param bool $shallow
      * @return SceneCollection
+     * @throws EmptyCollectionException
      */
     public static function selectScenes(ConversationCollection $conversations, bool $shallow = true): SceneCollection
     {
-        return new SceneCollection();
+        SelectorUtil::throwIfConversationObjectCollectionIsEmpty($conversations);
+
+        $scenes = ConversationDataClient::getAllScenes($conversations, $shallow);
+
+        /** @var SceneCollection $scenesWithPassingConditions */
+        $scenesWithPassingConditions = ConditionFilter::filterObjects($scenes);
+
+        return $scenesWithPassingConditions;
     }
 }

--- a/src/ConversationEngine/Reasoners/TurnSelector.php
+++ b/src/ConversationEngine/Reasoners/TurnSelector.php
@@ -14,12 +14,12 @@ class TurnSelector
 {
     public static function selectStartingTurns($scenes): TurnCollection
     {
+        /** @var TurnCollection $turns */
         $turns = ConversationDataClient::getAllStartingTurns($scenes);
 
-        $conditionPassingTurns = $turns->filter(function ($turn) {
-            ConditionFilter::checkConditions($turn);
-        });
+        /** @var TurnCollection $turnsWithPassingConditions */
+        $turnsWithPassingConditions = ConditionFilter::filterObjects($turns);
 
-        return $conditionPassingTurns;
+        return $turnsWithPassingConditions;
     }
 }

--- a/src/ConversationEngine/Reasoners/TurnSelector.php
+++ b/src/ConversationEngine/Reasoners/TurnSelector.php
@@ -3,6 +3,8 @@
 
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
+use OpenDialogAi\ConversationEngine\Exceptions\EmptyCollectionException;
+use OpenDialogAi\ConversationEngine\Util\SelectorUtil;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\SceneCollection;
 use OpenDialogAi\Core\Conversation\TurnCollection;
@@ -18,11 +20,13 @@ class TurnSelector
      * @param SceneCollection $scenes
      * @param bool $shallow
      * @return TurnCollection
+     * @throws EmptyCollectionException
      */
     public static function selectStartingTurns(SceneCollection $scenes, bool $shallow = true): TurnCollection
     {
-        /** @var TurnCollection $turns */
-        $turns = ConversationDataClient::getAllStartingTurns($scenes);
+        SelectorUtil::throwIfConversationObjectCollectionIsEmpty($scenes);
+
+        $turns = ConversationDataClient::getAllStartingTurns($scenes, $shallow);
 
         /** @var TurnCollection $turnsWithPassingConditions */
         $turnsWithPassingConditions = ConditionFilter::filterObjects($turns);
@@ -37,10 +41,18 @@ class TurnSelector
      * @param SceneCollection $scenes
      * @param bool $shallow
      * @return TurnCollection
+     * @throws EmptyCollectionException
      */
     public static function selectOpenTurns(SceneCollection $scenes, bool $shallow = true): TurnCollection
     {
-        return new TurnCollection();
+        SelectorUtil::throwIfConversationObjectCollectionIsEmpty($scenes);
+
+        $turns = ConversationDataClient::getAllOpenTurns($scenes, $shallow);
+
+        /** @var TurnCollection $turnsWithPassingConditions */
+        $turnsWithPassingConditions = ConditionFilter::filterObjects($turns);
+
+        return $turnsWithPassingConditions;
     }
 
     /**
@@ -50,9 +62,17 @@ class TurnSelector
      * @param SceneCollection $scenes
      * @param bool $shallow
      * @return TurnCollection
+     * @throws EmptyCollectionException
      */
     public static function selectTurns(SceneCollection $scenes, bool $shallow = true): TurnCollection
     {
-        return new TurnCollection();
+        SelectorUtil::throwIfConversationObjectCollectionIsEmpty($scenes);
+
+        $turns = ConversationDataClient::getAllTurns($scenes, $shallow);
+
+        /** @var TurnCollection $turnsWithPassingConditions */
+        $turnsWithPassingConditions = ConditionFilter::filterObjects($turns);
+
+        return $turnsWithPassingConditions;
     }
 }

--- a/src/ConversationEngine/Reasoners/TurnSelector.php
+++ b/src/ConversationEngine/Reasoners/TurnSelector.php
@@ -4,15 +4,22 @@
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
+use OpenDialogAi\Core\Conversation\SceneCollection;
 use OpenDialogAi\Core\Conversation\TurnCollection;
 
 /**
- * The TurnSelector should evaluate conditions against turns to select
- * which turns can validly be considered for a user
+ * This selector provides methods that select various types of turns and filters them by evaluating their conditions
  */
 class TurnSelector
 {
-    public static function selectStartingTurns($scenes): TurnCollection
+    /**
+     * Retrieves all turns that have the starting behaviour, within the given scenes
+     *
+     * @param SceneCollection $scenes
+     * @param bool $shallow
+     * @return TurnCollection
+     */
+    public static function selectStartingTurns(SceneCollection $scenes, bool $shallow = true): TurnCollection
     {
         /** @var TurnCollection $turns */
         $turns = ConversationDataClient::getAllStartingTurns($scenes);
@@ -21,5 +28,31 @@ class TurnSelector
         $turnsWithPassingConditions = ConditionFilter::filterObjects($turns);
 
         return $turnsWithPassingConditions;
+    }
+
+    /**
+     *
+     * Retrieves all turns that have the open behaviour, within the given scenes
+     *
+     * @param SceneCollection $scenes
+     * @param bool $shallow
+     * @return TurnCollection
+     */
+    public static function selectOpenTurns(SceneCollection $scenes, bool $shallow = true): TurnCollection
+    {
+        return new TurnCollection();
+    }
+
+    /**
+     *
+     * Retrieves all turns within the given scenes
+     *
+     * @param SceneCollection $scenes
+     * @param bool $shallow
+     * @return TurnCollection
+     */
+    public static function selectTurns(SceneCollection $scenes, bool $shallow = true): TurnCollection
+    {
+        return new TurnCollection();
     }
 }

--- a/src/ConversationEngine/Tests/ConditionFilterTest.php
+++ b/src/ConversationEngine/Tests/ConditionFilterTest.php
@@ -1,0 +1,80 @@
+<?php
+
+
+namespace OpenDialogAi\ConversationEngine\Tests;
+
+
+use OpenDialogAi\ContextEngine\Contexts\BaseContexts\SessionContext;
+use OpenDialogAi\ContextEngine\Facades\ContextService;
+use OpenDialogAi\ConversationEngine\Reasoners\ConditionFilter;
+use OpenDialogAi\Core\Conversation\Condition;
+use OpenDialogAi\Core\Conversation\ConditionCollection;
+use OpenDialogAi\Core\Conversation\IntentCollection;
+use OpenDialogAi\Core\Conversation\Scene;
+use OpenDialogAi\Core\Conversation\SceneCollection;
+use OpenDialogAi\Core\Conversation\Turn;
+use OpenDialogAi\Core\Conversation\TurnCollection;
+use OpenDialogAi\Core\Tests\TestCase;
+
+class ConditionFilterTest extends TestCase
+{
+    public function testEmptyCollection()
+    {
+        $intentCollection = new IntentCollection();
+
+        $this->assertCount(0, ConditionFilter::filterObjects($intentCollection));
+    }
+
+    public function testObjectsWithNoConditions()
+    {
+        $turn1 = new Turn();
+        $turn1->setODId('test_turn1');
+
+        $turn2 = new Turn();
+        $turn2->setODId('test_turn2');
+
+        $turn3 = new Turn();
+        $turn3->setODId('test_turn3');
+
+        $turnCollection = new TurnCollection([
+            $turn1,
+            $turn2,
+            $turn3,
+        ]);
+
+        $this->assertCount(3, ConditionFilter::filterObjects($turnCollection));
+    }
+
+    public function testObjectsWithConditions()
+    {
+        ContextService::saveAttribute(SessionContext::getComponentId().".first_name", 'test');
+
+        $expectedScene1 = new Scene();
+        $expectedScene1->setODId('test_scene1');
+        $expectedScene1->setConditions(new ConditionCollection([
+            new Condition('eq', ['attribute' => 'session.first_name'], ['value' => 'test'])
+        ]));
+
+        $notExpectedScene = new Scene();
+        $notExpectedScene->setODId('test_scene2');
+        $notExpectedScene->setConditions(new ConditionCollection([
+            new Condition('eq', ['attribute' => 'session.first_name'], ['value' => 'unknown'])
+        ]));
+
+        $expectedScene2 = new Scene();
+        $expectedScene2->setODId('test_scene3');
+        $expectedScene2->setConditions(new ConditionCollection([
+            new Condition('eq', ['attribute' => 'session.first_name'], ['value' => 'test'])
+        ]));
+
+        $sceneCollection = new SceneCollection([
+            $expectedScene1,
+            $notExpectedScene,
+            $expectedScene2,
+        ]);
+
+        $this->assertCount(2, ConditionFilter::filterObjects($sceneCollection));
+        $this->assertContains($expectedScene1, ConditionFilter::filterObjects($sceneCollection));
+        $this->assertContains($expectedScene2, ConditionFilter::filterObjects($sceneCollection));
+    }
+}

--- a/src/ConversationEngine/Tests/ConversationEngineTest.php
+++ b/src/ConversationEngine/Tests/ConversationEngineTest.php
@@ -2,23 +2,13 @@
 
 namespace OpenDialogAi\ConversationEngine\Tests;
 
-use OpenDialogAi\AttributeEngine\AttributeResolver\AttributeResolver;
-use OpenDialogAi\AttributeEngine\Attributes\IntAttribute;
-use OpenDialogAi\AttributeEngine\Attributes\StringAttribute;
 use OpenDialogAi\AttributeEngine\CoreAttributes\UserAttribute;
 use OpenDialogAi\AttributeEngine\CoreAttributes\UtteranceAttribute;
 use OpenDialogAi\ContextEngine\Contexts\User\UserDataClient;
-use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\ConversationEngine\ConversationEngine;
 use OpenDialogAi\ConversationEngine\ConversationEngineInterface;
 use OpenDialogAi\ConversationEngine\Exceptions\IncomingUtteranceNotValid;
-use OpenDialogAi\ConversationEngine\Reasoners\ScenarioSelector;
-use OpenDialogAi\ConversationEngine\Reasoners\StartingIntentSelector;
 use OpenDialogAi\ConversationEngine\Reasoners\UtteranceReasoner;
-use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
-use OpenDialogAi\Core\Conversation\Tests\ConversationGenerator;
-use OpenDialogAi\Core\Conversation\Tests\IntentGenerator;
-use OpenDialogAi\Core\Conversation\TurnCollection;
 use OpenDialogAi\Core\Tests\TestCase;
 use OpenDialogAi\Core\Tests\Utils\UserGenerator;
 use OpenDialogAi\Core\Tests\Utils\UtteranceGenerator;
@@ -63,30 +53,4 @@ class ConversationEngineTest extends TestCase
         $this->assertEquals(UserAttribute::CURRENT_USER, $userAttribute->getId());
 
     }
-
-    public function testScenarioSelector()
-    {
-        ConversationDataClient::shouldReceive('getAllActiveScenarios')->once()
-            ->andReturn(ConversationGenerator::generateScenariosWithEverything('test'), 1);
-
-        $conditionPassingScenarios = ScenarioSelector::selectActiveScenarios();
-    }
-
-    public function testIncomingIntentSelector()
-    {
-        $intents = ConversationDataClient::shouldReceive('getAllStartingIntents')->once()
-            ->andReturn(IntentGenerator::generateIntents());
-
-        $utterance = UtteranceGenerator::generateButtonResponseUtterance('intent.core.I3');
-
-        ContextService::saveAttribute(
-          'user'.'.'.UtteranceAttribute::UTTERANCE, $utterance
-        );
-
-        $matchingIntents = StartingIntentSelector::selectStartingIntents(new TurnCollection());
-
-        $this->assertCount(1, $matchingIntents);
-        $this->assertEquals('intent.core.I3', $matchingIntents->pop()->getODId());
-    }
-
 }

--- a/src/ConversationEngine/Tests/SelectorTest.php
+++ b/src/ConversationEngine/Tests/SelectorTest.php
@@ -4,8 +4,8 @@ namespace OpenDialogAi\ConversationEngine\Tests;
 
 use OpenDialogAi\AttributeEngine\CoreAttributes\UtteranceAttribute;
 use OpenDialogAi\ContextEngine\Facades\ContextService;
+use OpenDialogAi\ConversationEngine\Reasoners\IntentSelector;
 use OpenDialogAi\ConversationEngine\Reasoners\ScenarioSelector;
-use OpenDialogAi\ConversationEngine\Reasoners\StartingIntentSelector;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\Tests\ConversationGenerator;
 use OpenDialogAi\Core\Conversation\Tests\IntentGenerator;
@@ -35,7 +35,7 @@ class SelectorTest extends TestCase
             'user'.'.'.UtteranceAttribute::UTTERANCE, $utterance
         );
 
-        $matchingIntents = StartingIntentSelector::selectStartingIntents(new TurnCollection());
+        $matchingIntents = IntentSelector::selectStartingIntents(new TurnCollection());
 
         $this->assertCount(1, $matchingIntents);
         $this->assertEquals('intent.core.I3', $matchingIntents->pop()->getODId());

--- a/src/ConversationEngine/Tests/SelectorTest.php
+++ b/src/ConversationEngine/Tests/SelectorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace OpenDialogAi\ConversationEngine\Tests;
+
+use OpenDialogAi\AttributeEngine\CoreAttributes\UtteranceAttribute;
+use OpenDialogAi\ContextEngine\Facades\ContextService;
+use OpenDialogAi\ConversationEngine\Reasoners\ScenarioSelector;
+use OpenDialogAi\ConversationEngine\Reasoners\StartingIntentSelector;
+use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
+use OpenDialogAi\Core\Conversation\Tests\ConversationGenerator;
+use OpenDialogAi\Core\Conversation\Tests\IntentGenerator;
+use OpenDialogAi\Core\Conversation\TurnCollection;
+use OpenDialogAi\Core\Tests\TestCase;
+use OpenDialogAi\Core\Tests\Utils\UtteranceGenerator;
+
+
+class SelectorTest extends TestCase
+{
+    public function testScenarioSelector()
+    {
+        ConversationDataClient::shouldReceive('getAllActiveScenarios')->once()
+            ->andReturn(ConversationGenerator::generateScenariosWithEverything('test'), 1);
+
+        $conditionPassingScenarios = ScenarioSelector::selectActiveScenarios();
+    }
+
+    public function testIncomingIntentSelector()
+    {
+        $intents = ConversationDataClient::shouldReceive('getAllStartingIntents')->once()
+            ->andReturn(IntentGenerator::generateIntents());
+
+        $utterance = UtteranceGenerator::generateButtonResponseUtterance('intent.core.I3');
+
+        ContextService::saveAttribute(
+            'user'.'.'.UtteranceAttribute::UTTERANCE, $utterance
+        );
+
+        $matchingIntents = StartingIntentSelector::selectStartingIntents(new TurnCollection());
+
+        $this->assertCount(1, $matchingIntents);
+        $this->assertEquals('intent.core.I3', $matchingIntents->pop()->getODId());
+    }
+}

--- a/src/ConversationEngine/Tests/SelectorTest.php
+++ b/src/ConversationEngine/Tests/SelectorTest.php
@@ -2,42 +2,81 @@
 
 namespace OpenDialogAi\ConversationEngine\Tests;
 
-use OpenDialogAi\AttributeEngine\CoreAttributes\UtteranceAttribute;
-use OpenDialogAi\ContextEngine\Facades\ContextService;
+use OpenDialogAi\ConversationEngine\Exceptions\EmptyCollectionException;
 use OpenDialogAi\ConversationEngine\Reasoners\IntentSelector;
 use OpenDialogAi\ConversationEngine\Reasoners\ScenarioSelector;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
+use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\IntentCollection;
+use OpenDialogAi\Core\Conversation\Scenario;
+use OpenDialogAi\Core\Conversation\ScenarioCollection;
 use OpenDialogAi\Core\Conversation\Tests\ConversationGenerator;
 use OpenDialogAi\Core\Conversation\Tests\IntentGenerator;
 use OpenDialogAi\Core\Conversation\TurnCollection;
 use OpenDialogAi\Core\Tests\TestCase;
-use OpenDialogAi\Core\Tests\Utils\UtteranceGenerator;
 
 
 class SelectorTest extends TestCase
 {
-    public function testScenarioSelector()
+    public function testScenarioSelectorSelectScenariosShallow()
     {
-        ConversationDataClient::shouldReceive('getAllActiveScenarios')->once()
+        // TODO: Create shallow generator
+        ConversationDataClient::shouldReceive('getAllActiveScenarios')
+            ->once()
             ->andReturn(ConversationGenerator::generateScenariosWithEverything('test'), 1);
 
-        $conditionPassingScenarios = ScenarioSelector::selectActiveScenarios();
+        /** @var Scenario[]|ScenarioCollection $shallowScenarios */
+        $shallowScenarios = ScenarioSelector::selectScenarios(true);
+
+        // There were four scenarios, but one was filtered out by conditions and another was deactivated
+        $this->assertCount(2, $shallowScenarios);
+
+        // We requested shallow scenarios so they shouldn't have references to other conversation objects
+        $this->assertCount(0, $shallowScenarios[0]->getConversations());
+        $this->assertCount(0, $shallowScenarios[1]->getConversations());
     }
 
-    public function testIncomingIntentSelector()
+    public function testScenarioSelectorSelectScenariosNonShallow()
     {
-        $intents = ConversationDataClient::shouldReceive('getAllStartingIntents')->once()
+        ConversationDataClient::shouldReceive('getAllActiveScenarios')
+            ->once()
+            ->andReturn(ConversationGenerator::generateScenariosWithEverything('test'), 1);
+
+        /** @var Scenario[]|ScenarioCollection $shallowScenarios */
+        $shallowScenarios = ScenarioSelector::selectScenarios(false);
+
+        // There were four scenarios, but one was filtered out by conditions and another was deactivated
+        $this->assertCount(2, $shallowScenarios);
+
+        // We requested non-shallow scenarios so they should have references to other conversation objects
+        $this->assertCount(1, $shallowScenarios[0]->getConversations());
+        $this->assertCount(1, $shallowScenarios[1]->getConversations());
+    }
+
+    public function testIntentSelectorSelectStartingIntentsNoTurns()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        IntentSelector::selectStartingIntents(new TurnCollection());
+    }
+
+    public function testIntentSelectorSelectStartingIntentsShallow()
+    {
+        // TODO: Create shallow generator
+        ConversationDataClient::shouldReceive('getAllStartingIntents')
+            ->once()
             ->andReturn(IntentGenerator::generateIntents());
 
-        $utterance = UtteranceGenerator::generateButtonResponseUtterance('intent.core.I3');
+        // TODO: Generate shallow turns with conditions
+        $turns = new TurnCollection();
 
-        ContextService::saveAttribute(
-            'user'.'.'.UtteranceAttribute::UTTERANCE, $utterance
-        );
+        /** @var Intent[]|IntentCollection $shallowIntents */
+        $shallowIntents = IntentSelector::selectStartingIntents($turns, true);
 
-        $matchingIntents = IntentSelector::selectStartingIntents(new TurnCollection());
+        // There were three intents, but one was filtered out by conditions and another was not starting
+        $this->assertCount(2, $shallowIntents);
 
-        $this->assertCount(1, $matchingIntents);
-        $this->assertEquals('intent.core.I3', $matchingIntents->pop()->getODId());
+        // We requested shallow intents so they shouldn't have references to other conversation objects
+        $this->assertNull($shallowIntents[0]->getTurn());
+        $this->assertNull($shallowIntents[1]->getTurn());
     }
 }

--- a/src/ConversationEngine/Tests/SelectorTest.php
+++ b/src/ConversationEngine/Tests/SelectorTest.php
@@ -2,81 +2,508 @@
 
 namespace OpenDialogAi\ConversationEngine\Tests;
 
+use OpenDialogAi\ContextEngine\Contexts\BaseContexts\SessionContext;
+use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\ConversationEngine\Exceptions\EmptyCollectionException;
+use OpenDialogAi\ConversationEngine\Reasoners\ConversationSelector;
 use OpenDialogAi\ConversationEngine\Reasoners\IntentSelector;
 use OpenDialogAi\ConversationEngine\Reasoners\ScenarioSelector;
+use OpenDialogAi\ConversationEngine\Reasoners\SceneSelector;
+use OpenDialogAi\ConversationEngine\Reasoners\TurnSelector;
+use OpenDialogAi\Core\Components\Exceptions\MissingRequiredComponentDataException;
+use OpenDialogAi\Core\Conversation\Behavior;
+use OpenDialogAi\Core\Conversation\BehaviorsCollection;
+use OpenDialogAi\Core\Conversation\Condition;
+use OpenDialogAi\Core\Conversation\ConditionCollection;
+use OpenDialogAi\Core\Conversation\ConversationCollection;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
-use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\IntentCollection;
 use OpenDialogAi\Core\Conversation\Scenario;
 use OpenDialogAi\Core\Conversation\ScenarioCollection;
+use OpenDialogAi\Core\Conversation\SceneCollection;
 use OpenDialogAi\Core\Conversation\Tests\ConversationGenerator;
-use OpenDialogAi\Core\Conversation\Tests\IntentGenerator;
 use OpenDialogAi\Core\Conversation\TurnCollection;
 use OpenDialogAi\Core\Tests\TestCase;
 
 
 class SelectorTest extends TestCase
 {
-    public function testScenarioSelectorSelectScenariosShallow()
+    /**
+     * @var ConditionCollection
+     */
+    private ConditionCollection $passingConditions;
+    /**
+     * @var ConditionCollection
+     */
+    private ConditionCollection $failingConditions;
+
+    /**
+     * @throws MissingRequiredComponentDataException
+     */
+    protected function setUp(): void
     {
-        // TODO: Create shallow generator
-        ConversationDataClient::shouldReceive('getAllActiveScenarios')
-            ->once()
-            ->andReturn(ConversationGenerator::generateScenariosWithEverything('test'), 1);
+        parent::setUp();
 
-        /** @var Scenario[]|ScenarioCollection $shallowScenarios */
-        $shallowScenarios = ScenarioSelector::selectScenarios(true);
+        ContextService::saveAttribute(SessionContext::getComponentId().".first_name", 'test');
 
-        // There were four scenarios, but one was filtered out by conditions and another was deactivated
-        $this->assertCount(2, $shallowScenarios);
+        $this->passingConditions = new ConditionCollection([
+            new Condition('eq', ['attribute' => 'session.first_name'], ['value' => 'test'])
+        ]);
 
-        // We requested shallow scenarios so they shouldn't have references to other conversation objects
-        $this->assertCount(0, $shallowScenarios[0]->getConversations());
-        $this->assertCount(0, $shallowScenarios[1]->getConversations());
+        $this->failingConditions = new ConditionCollection([
+            new Condition('eq', ['attribute' => 'session.first_name'], ['value' => 'unknown'])
+        ]);
     }
 
-    public function testScenarioSelectorSelectScenariosNonShallow()
-    {
-        ConversationDataClient::shouldReceive('getAllActiveScenarios')
-            ->once()
-            ->andReturn(ConversationGenerator::generateScenariosWithEverything('test'), 1);
-
-        /** @var Scenario[]|ScenarioCollection $shallowScenarios */
-        $shallowScenarios = ScenarioSelector::selectScenarios(false);
-
-        // There were four scenarios, but one was filtered out by conditions and another was deactivated
-        $this->assertCount(2, $shallowScenarios);
-
-        // We requested non-shallow scenarios so they should have references to other conversation objects
-        $this->assertCount(1, $shallowScenarios[0]->getConversations());
-        $this->assertCount(1, $shallowScenarios[1]->getConversations());
-    }
-
-    public function testIntentSelectorSelectStartingIntentsNoTurns()
+    public function testIntentSelectorSelectRequestIntentsNoTurns()
     {
         $this->expectException(EmptyCollectionException::class);
-        IntentSelector::selectStartingIntents(new TurnCollection());
+        IntentSelector::selectRequestIntents(new TurnCollection());
     }
 
-    public function testIntentSelectorSelectStartingIntentsShallow()
+    public function testIntentSelectorSelectRequestIntents()
     {
-        // TODO: Create shallow generator
-        ConversationDataClient::shouldReceive('getAllStartingIntents')
+        $intent1 = ConversationGenerator::createAppIntent('intent_1', $this->passingConditions);
+        $intent2 = ConversationGenerator::createAppIntent('intent_2', $this->failingConditions);
+        $intent3 = ConversationGenerator::createAppIntent('intent_3', $this->passingConditions);
+
+        $intents = new IntentCollection([$intent1, $intent2, $intent3]);
+
+        $turn = ConversationGenerator::createTurn('turn_1');
+        $turn->setRequestIntents($intents);
+
+        ConversationDataClient::shouldReceive('getAllRequestIntents')
             ->once()
-            ->andReturn(IntentGenerator::generateIntents());
+            ->andReturn($intents);
 
-        // TODO: Generate shallow turns with conditions
-        $turns = new TurnCollection();
+        /** @var Scenario[]|ScenarioCollection $selectedIntents */
+        $selectedIntents = IntentSelector::selectRequestIntents(new TurnCollection([$turn]));
 
-        /** @var Intent[]|IntentCollection $shallowIntents */
-        $shallowIntents = IntentSelector::selectStartingIntents($turns, true);
+        // There were three objects, but one was filtered out by conditions
+        $this->assertCount(2, $selectedIntents);
+        $this->assertContains($intent1, $selectedIntents);
+        $this->assertContains($intent3, $selectedIntents);
+    }
 
-        // There were three intents, but one was filtered out by conditions and another was not starting
-        $this->assertCount(2, $shallowIntents);
+    public function testIntentSelectorSelectResponseIntentsNoTurns()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        IntentSelector::selectResponseIntents(new TurnCollection());
+    }
 
-        // We requested shallow intents so they shouldn't have references to other conversation objects
-        $this->assertNull($shallowIntents[0]->getTurn());
-        $this->assertNull($shallowIntents[1]->getTurn());
+    public function testIntentSelectorSelectResponseIntents()
+    {
+        $intent1 = ConversationGenerator::createAppIntent('intent_1', $this->passingConditions);
+        $intent2 = ConversationGenerator::createAppIntent('intent_2', $this->failingConditions);
+        $intent3 = ConversationGenerator::createAppIntent('intent_3', $this->passingConditions);
+
+        $intents = new IntentCollection([$intent1, $intent2, $intent3]);
+
+        $turn = ConversationGenerator::createTurn('turn_1');
+        $turn->setResponseIntents($intents);
+
+        ConversationDataClient::shouldReceive('getAllResponseIntents')
+            ->once()
+            ->andReturn($intents);
+
+        /** @var Scenario[]|ScenarioCollection $selectedIntents */
+        $selectedIntents = IntentSelector::selectResponseIntents(new TurnCollection([$turn]));
+
+        // There were three objects, but one was filtered out by conditions
+        $this->assertCount(2, $selectedIntents);
+        $this->assertContains($intent1, $selectedIntents);
+        $this->assertContains($intent3, $selectedIntents);
+    }
+
+    public function testIntentSelectorSelectRequestIntentsByIdNoTurns()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        IntentSelector::selectRequestIntentsById(new TurnCollection(), 'intent_3');
+    }
+
+    public function testIntentSelectorSelectRequestIntentsById()
+    {
+        $intent1Passing = ConversationGenerator::createAppIntent('intent_1', $this->passingConditions);
+        $intent1Failing = ConversationGenerator::createAppIntent('intent_1', $this->failingConditions);
+        $intent2 = ConversationGenerator::createAppIntent('intent_2', $this->passingConditions);
+
+        $intents = new IntentCollection([$intent1Passing, $intent1Failing, $intent2]);
+
+        $turn = ConversationGenerator::createTurn('turn_1');
+        $turn->setRequestIntents($intents);
+
+        ConversationDataClient::shouldReceive('getAllRequestIntentsById')
+            ->once()
+            ->andReturn($intents);
+
+        /** @var Scenario[]|ScenarioCollection $selectedIntents */
+        $selectedIntents = IntentSelector::selectRequestIntentsById(new TurnCollection([$turn]), 'intent_1');
+
+        // There were three objects, two had the desired ID, but one was filtered out by conditions
+        $this->assertCount(1, $selectedIntents);
+        $this->assertContains($intent1Passing, $selectedIntents);
+    }
+
+    public function testIntentSelectorSelectResponseIntentsByIdNoTurns()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        IntentSelector::selectResponseIntentsById(new TurnCollection(), 'intent_1');
+    }
+
+    public function testIntentSelectorSelectResponseIntentsById()
+    {
+        $intent1Passing = ConversationGenerator::createUserIntent('intent_1', $this->passingConditions);
+        $intent1Failing = ConversationGenerator::createUserIntent('intent_1', $this->failingConditions);
+        $intent2 = ConversationGenerator::createUserIntent('intent_2', $this->passingConditions);
+
+        $intents = new IntentCollection([$intent1Passing, $intent1Failing, $intent2]);
+
+        $turn = ConversationGenerator::createTurn('turn_1');
+        $turn->setResponseIntents($intents);
+
+        ConversationDataClient::shouldReceive('getAllResponseIntentsById')
+            ->once()
+            ->andReturn($intents);
+
+        /** @var Scenario[]|ScenarioCollection $selectedIntents */
+        $selectedIntents = IntentSelector::selectResponseIntentsById(new TurnCollection([$turn]), 'intent_1');
+
+        // There were three objects, two had the desired ID, but one was filtered out by conditions
+        $this->assertCount(1, $selectedIntents);
+        $this->assertContains($intent1Passing, $selectedIntents);
+    }
+
+    public function testTurnSelectorSelectStartingTurnsNoTurns()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        TurnSelector::selectStartingTurns(new SceneCollection());
+    }
+
+    public function testTurnSelectorSelectStartingTurns()
+    {
+        $behaviors = new BehaviorsCollection(new Behavior(Behavior::STARTING_BEHAVIOR));
+
+        $turn1 = ConversationGenerator::createTurn('turn_1', $this->passingConditions);
+        $turn1->setBehaviors($behaviors);
+
+        $turn2 = ConversationGenerator::createTurn('turn_2', $this->failingConditions);
+        $turn2->setBehaviors($behaviors);
+
+        $turn3 = ConversationGenerator::createTurn('turn_3', $this->passingConditions);
+        $turn3->setBehaviors($behaviors);
+
+        $turns = new TurnCollection([$turn1, $turn2, $turn3]);
+
+        $scene = ConversationGenerator::createScene('scene_1');
+        $scene->setTurns($turns);
+
+        ConversationDataClient::shouldReceive('getAllStartingTurns')
+            ->once()
+            ->andReturn($turns);
+
+        /** @var Scenario[]|ScenarioCollection $selectedTurns */
+        $selectedTurns = TurnSelector::selectStartingTurns(new SceneCollection([$scene]));
+
+        // There were three objects but one was filtered out by conditions
+        $this->assertCount(2, $selectedTurns);
+        $this->assertContains($turn1, $selectedTurns);
+        $this->assertContains($turn3, $selectedTurns);
+    }
+
+    public function testTurnSelectorSelectOpenTurnsNoTurns()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        TurnSelector::selectOpenTurns(new SceneCollection());
+    }
+
+    public function testTurnSelectorSelectOpenTurns()
+    {
+        $behaviors = new BehaviorsCollection(new Behavior(Behavior::OPEN_BEHAVIOR));
+
+        $turn1 = ConversationGenerator::createTurn('turn_1', $this->passingConditions);
+        $turn1->setBehaviors($behaviors);
+
+        $turn2 = ConversationGenerator::createTurn('turn_2', $this->failingConditions);
+        $turn2->setBehaviors($behaviors);
+
+        $turn3 = ConversationGenerator::createTurn('turn_3', $this->passingConditions);
+        $turn3->setBehaviors($behaviors);
+
+
+        $turns = new TurnCollection([$turn1, $turn2, $turn3]);
+
+        $scene = ConversationGenerator::createScene('scene_1');
+        $scene->setTurns($turns);
+
+        ConversationDataClient::shouldReceive('getAllOpenTurns')
+            ->once()
+            ->andReturn($turns);
+
+        /** @var Scenario[]|ScenarioCollection $selectedTurns */
+        $selectedTurns = TurnSelector::selectOpenTurns(new SceneCollection([$scene]));
+
+        // There were three objects but one was filtered out by conditions
+        $this->assertCount(2, $selectedTurns);
+        $this->assertContains($turn1, $selectedTurns);
+        $this->assertContains($turn3, $selectedTurns);
+    }
+
+    public function testTurnSelectorSelectTurnsNoTurns()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        TurnSelector::selectTurns(new SceneCollection());
+    }
+
+    public function testTurnSelectorSelectTurns()
+    {
+        $turn1 = ConversationGenerator::createTurn('turn_1', $this->passingConditions);
+        $turn2 = ConversationGenerator::createTurn('turn_2', $this->failingConditions);
+        $turn3 = ConversationGenerator::createTurn('turn_3', $this->passingConditions);
+
+        $turns = new TurnCollection([$turn1, $turn2, $turn3]);
+
+        $scene = ConversationGenerator::createScene('scene_1');
+        $scene->setTurns($turns);
+
+        ConversationDataClient::shouldReceive('getAllTurns')
+            ->once()
+            ->andReturn($turns);
+
+        /** @var Scenario[]|ScenarioCollection $selectedTurns */
+        $selectedTurns = TurnSelector::selectTurns(new SceneCollection([$scene]));
+
+        // There were three objects but one was filtered out by conditions
+        $this->assertCount(2, $selectedTurns);
+        $this->assertContains($turn1, $selectedTurns);
+        $this->assertContains($turn3, $selectedTurns);
+    }
+
+    public function testSceneSelectorSelectStartingScenesNoScenes()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        SceneSelector::selectStartingScenes(new ConversationCollection());
+    }
+
+    public function testSceneSelectorSelectStartingScenes()
+    {
+        $behaviors = new BehaviorsCollection(new Behavior(Behavior::STARTING_BEHAVIOR));
+
+        $scene1 = ConversationGenerator::createScene('scene_1', $this->passingConditions);
+        $scene1->setBehaviors($behaviors);
+
+        $scene2 = ConversationGenerator::createScene('scene_2', $this->failingConditions);
+        $scene2->setBehaviors($behaviors);
+
+        $scene3 = ConversationGenerator::createScene('scene_3', $this->passingConditions);
+        $scene3->setBehaviors($behaviors);
+
+        $scenes = new SceneCollection([$scene1, $scene2, $scene3]);
+
+        $conversation = ConversationGenerator::createConversation('conversation_1');
+        $conversation->setScenes($scenes);
+
+        ConversationDataClient::shouldReceive('getAllStartingScenes')
+            ->once()
+            ->andReturn($scenes);
+
+        /** @var Scenario[]|ScenarioCollection $selectedScenes */
+        $selectedScenes = SceneSelector::selectStartingScenes(new ConversationCollection([$conversation]));
+
+        // There were three objects but one was filtered out by conditions
+        $this->assertCount(2, $selectedScenes);
+        $this->assertContains($scene1, $selectedScenes);
+        $this->assertContains($scene3, $selectedScenes);
+    }
+
+    public function testSceneSelectorSelectOpenScenesNoScenes()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        SceneSelector::selectOpenScenes(new ConversationCollection());
+    }
+
+    public function testSceneSelectorSelectOpenScenes()
+    {
+        $behaviors = new BehaviorsCollection(new Behavior(Behavior::OPEN_BEHAVIOR));
+
+        $scene1 = ConversationGenerator::createScene('scene_1', $this->passingConditions);
+        $scene1->setBehaviors($behaviors);
+
+        $scene2 = ConversationGenerator::createScene('scene_2', $this->failingConditions);
+        $scene2->setBehaviors($behaviors);
+
+        $scene3 = ConversationGenerator::createScene('scene_3', $this->passingConditions);
+        $scene3->setBehaviors($behaviors);
+
+        $scenes = new SceneCollection([$scene1, $scene2, $scene3]);
+
+        $conversation = ConversationGenerator::createConversation('conversation_1');
+        $conversation->setScenes($scenes);
+
+        ConversationDataClient::shouldReceive('getAllOpenScenes')
+            ->once()
+            ->andReturn($scenes);
+
+        /** @var Scenario[]|ScenarioCollection $selectedScenes */
+        $selectedScenes = SceneSelector::selectOpenScenes(new ConversationCollection([$conversation]));
+
+        // There were three objects but one was filtered out by conditions
+        $this->assertCount(2, $selectedScenes);
+        $this->assertContains($scene1, $selectedScenes);
+        $this->assertContains($scene3, $selectedScenes);
+    }
+
+    public function testSceneSelectorSelectScenesNoScenes()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        SceneSelector::selectScenes(new ConversationCollection());
+    }
+
+    public function testSceneSelectorSelectScenes()
+    {
+        $scene1 = ConversationGenerator::createScene('scene_1', $this->passingConditions);
+        $scene2 = ConversationGenerator::createScene('scene_2', $this->failingConditions);
+        $scene3 = ConversationGenerator::createScene('scene_3', $this->passingConditions);
+
+        $scenes = new SceneCollection([$scene1, $scene2, $scene3]);
+
+        $conversation = ConversationGenerator::createConversation('conversation_1');
+        $conversation->setScenes($scenes);
+
+        ConversationDataClient::shouldReceive('getAllScenes')
+            ->once()
+            ->andReturn($scenes);
+
+        /** @var Scenario[]|ScenarioCollection $selectedScenes */
+        $selectedScenes = SceneSelector::selectScenes(new ConversationCollection([$conversation]));
+
+        // There were three objects but one was filtered out by conditions
+        $this->assertCount(2, $selectedScenes);
+        $this->assertContains($scene1, $selectedScenes);
+        $this->assertContains($scene3, $selectedScenes);
+    }
+
+    public function testConversationSelectorSelectStartingConversationsNoConversations()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        ConversationSelector::selectStartingConversations(new ScenarioCollection());
+    }
+
+    public function testConversationSelectorSelectStartingConversations()
+    {
+        $behaviors = new BehaviorsCollection(new Behavior(Behavior::STARTING_BEHAVIOR));
+
+        $conversation1 = ConversationGenerator::createConversation('conversation_1', $this->passingConditions);
+        $conversation1->setBehaviors($behaviors);
+
+        $conversation2 = ConversationGenerator::createConversation('conversation_2', $this->failingConditions);
+        $conversation2->setBehaviors($behaviors);
+
+        $conversation3 = ConversationGenerator::createConversation('conversation_3', $this->passingConditions);
+        $conversation3->setBehaviors($behaviors);
+
+        $conversations = new SceneCollection([$conversation1, $conversation2, $conversation3]);
+
+        $scenario = ConversationGenerator::createConversation('scenario_1');
+        $scenario->setScenes($conversations);
+
+        ConversationDataClient::shouldReceive('getAllStartingConversations')
+            ->once()
+            ->andReturn($conversations);
+
+        /** @var Scenario[]|ScenarioCollection $selectedConversations */
+        $selectedConversations = ConversationSelector::selectStartingConversations(new ScenarioCollection([$scenario]));
+
+        // There were three objects but one was filtered out by conditions
+        $this->assertCount(2, $selectedConversations);
+        $this->assertContains($conversation1, $selectedConversations);
+        $this->assertContains($conversation3, $selectedConversations);
+    }
+
+    public function testConversationSelectorSelectOpenConversationsNoConversations()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        ConversationSelector::selectOpenConversations(new ScenarioCollection());
+    }
+
+    public function testConversationSelectorSelectOpenConversations()
+    {
+        $behaviors = new BehaviorsCollection(new Behavior(Behavior::OPEN_BEHAVIOR));
+
+        $conversation1 = ConversationGenerator::createConversation('conversation_1', $this->passingConditions);
+        $conversation1->setBehaviors($behaviors);
+
+        $conversation2 = ConversationGenerator::createConversation('conversation_2', $this->failingConditions);
+        $conversation2->setBehaviors($behaviors);
+
+        $conversation3 = ConversationGenerator::createConversation('conversation_3', $this->passingConditions);
+        $conversation3->setBehaviors($behaviors);
+
+        $conversations = new SceneCollection([$conversation1, $conversation2, $conversation3]);
+
+        $scenario = ConversationGenerator::createConversation('scenario_1');
+        $scenario->setScenes($conversations);
+
+        ConversationDataClient::shouldReceive('getAllOpenConversations')
+            ->once()
+            ->andReturn($conversations);
+
+        /** @var Scenario[]|ScenarioCollection $selectedConversations */
+        $selectedConversations = ConversationSelector::selectOpenConversations(new ScenarioCollection([$scenario]));
+
+        // There were three objects but one was filtered out by conditions
+        $this->assertCount(2, $selectedConversations);
+        $this->assertContains($conversation1, $selectedConversations);
+        $this->assertContains($conversation3, $selectedConversations);
+    }
+
+    public function testConversationSelectorSelectConversationsNoConversations()
+    {
+        $this->expectException(EmptyCollectionException::class);
+        ConversationSelector::selectConversations(new ScenarioCollection());
+    }
+
+    public function testConversationSelectorSelectConversations()
+    {
+        $conversation1 = ConversationGenerator::createConversation('conversation_1', $this->passingConditions);
+        $conversation2 = ConversationGenerator::createConversation('conversation_2', $this->failingConditions);
+        $conversation3 = ConversationGenerator::createConversation('conversation_3', $this->passingConditions);
+
+        $conversations = new SceneCollection([$conversation1, $conversation2, $conversation3]);
+
+        $scenario = ConversationGenerator::createConversation('scenario_1');
+        $scenario->setScenes($conversations);
+
+        ConversationDataClient::shouldReceive('getAllConversations')
+            ->once()
+            ->andReturn($conversations);
+
+        /** @var Scenario[]|ScenarioCollection $selectedConversations */
+        $selectedConversations = ConversationSelector::selectConversations(new ScenarioCollection([$scenario]));
+
+        // There were three objects but one was filtered out by conditions
+        $this->assertCount(2, $selectedConversations);
+        $this->assertContains($conversation1, $selectedConversations);
+        $this->assertContains($conversation3, $selectedConversations);
+    }
+
+    public function testScenarioSelectorSelectScenarios()
+    {
+        $scenario1 = ConversationGenerator::createScenario('scenario_1', $this->passingConditions);
+        $scenario2 = ConversationGenerator::createScenario('scenario_2', $this->failingConditions);
+        $scenario3 = ConversationGenerator::createScenario('scenario_3', $this->passingConditions);
+
+        $scenarios = new ScenarioCollection([$scenario1, $scenario2, $scenario3]);
+
+        ConversationDataClient::shouldReceive('getAllActiveScenarios')
+            ->once()
+            ->andReturn($scenarios);
+
+        /** @var Scenario[]|ScenarioCollection $selectedScenarios */
+        $selectedScenarios = ScenarioSelector::selectScenarios();
+
+        // There were three objects, but one was filtered out by conditions
+        $this->assertCount(2, $selectedScenarios);
+        $this->assertContains($scenario1, $selectedScenarios);
+        $this->assertContains($scenario3, $selectedScenarios);
     }
 }

--- a/src/ConversationEngine/Util/SelectorUtil.php
+++ b/src/ConversationEngine/Util/SelectorUtil.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace OpenDialogAi\ConversationEngine\Util;
+
+
+use OpenDialogAi\ConversationEngine\Exceptions\EmptyCollectionException;
+use OpenDialogAi\Core\Conversation\ODObjectCollection;
+
+class SelectorUtil
+{
+    /**
+     * @param ODObjectCollection $collection
+     * @throws EmptyCollectionException
+     */
+    public static function throwIfConversationObjectCollectionIsEmpty(ODObjectCollection $collection): void
+    {
+        if ($collection->isEmpty()) {
+            throw new EmptyCollectionException();
+        }
+    }
+}

--- a/src/InterpreterEngine/Facades/InterpreterService.php
+++ b/src/InterpreterEngine/Facades/InterpreterService.php
@@ -2,15 +2,18 @@
 namespace OpenDialogAi\InterpreterEngine\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use OpenDialogAi\AttributeEngine\CoreAttributes\UtteranceAttribute;
+use OpenDialogAi\Core\Conversation\IntentCollection;
+use OpenDialogAi\InterpreterEngine\Service\InterpreterServiceInterface;
 
+/**
+ * @method static IntentCollection interpret(string $interpreterName, UtteranceAttribute $utterance)
+ * @method static IntentCollection interpretDefaultInterpreter(UtteranceAttribute $utterance)
+ */
 class InterpreterService extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        /**
-         * @method static function interpret(string $interpreterName, UtteranceAttribute $utterance): IntentCollection
-         * @method static function interpretDefaultInterpreter(UtteranceAttribute $utterance): IntentCollection
-         */
-        return \OpenDialogAi\InterpreterEngine\Service\InterpreterServiceInterface::class;
+        return InterpreterServiceInterface::class;
     }
 }

--- a/src/OperationEngine/BaseOperation.php
+++ b/src/OperationEngine/BaseOperation.php
@@ -3,6 +3,7 @@
 namespace OpenDialogAi\OperationEngine;
 
 use Illuminate\Support\Facades\Log;
+use OpenDialogAi\AttributeEngine\Contracts\Attribute;
 use OpenDialogAi\Core\Components\Contracts\OpenDialogComponent;
 use OpenDialogAi\Core\Components\ODComponent;
 use OpenDialogAi\Core\Components\ODComponentTypes;
@@ -26,7 +27,7 @@ abstract class BaseOperation implements OperationInterface, OpenDialogComponent
     ];
 
     /**
-     * @var \OpenDialogAi\AttributeEngine\Attributes\Attribute[]
+     * @var Attribute[]
      */
     protected $attributes;
 

--- a/src/OperationEngine/Facade/OperationService.php
+++ b/src/OperationEngine/Facade/OperationService.php
@@ -2,8 +2,17 @@
 namespace OpenDialogAi\OperationEngine\Facade;
 
 use Illuminate\Support\Facades\Facade;
+use OpenDialogAi\Core\Conversation\Condition;
+use OpenDialogAi\OperationEngine\OperationInterface;
+use OpenDialogAi\OperationEngine\Service\OperationServiceInterface;
 
-
+/**
+ * @method static array getAvailableOperations()
+ * @method static bool isOperationAvailable(string $operationName)
+ * @method static OperationInterface getOperation($operationName)
+ * @method static void registerAvailableOperations($operations)
+ * @method static bool checkCondition(Condition $condition)
+ */
 class OperationService extends Facade
 {
     /**
@@ -11,6 +20,6 @@ class OperationService extends Facade
      **/
     protected static function getFacadeAccessor()
     {
-        return \OpenDialogAi\OperationEngine\Service\OperationServiceInterface::class;
+        return OperationServiceInterface::class;
     }
 }

--- a/src/OperationEngine/Service/OperationService.php
+++ b/src/OperationEngine/Service/OperationService.php
@@ -7,8 +7,8 @@ use OpenDialogAi\AttributeEngine\Contracts\Attribute;
 use OpenDialogAi\AttributeEngine\Exceptions\AttributeDoesNotExistException;
 use OpenDialogAi\AttributeEngine\Facades\AttributeResolver;
 use OpenDialogAi\ContextEngine\ContextService\ContextParser;
-use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\ContextEngine\ContextService\ParsedAttributeName;
+use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\Core\Components\Exceptions\InvalidComponentDataException;
 use OpenDialogAi\Core\Components\Exceptions\MissingRequiredComponentDataException;
 use OpenDialogAi\Core\Conversation\Condition;
@@ -96,7 +96,7 @@ class OperationService implements OperationServiceInterface
     /**
      * @inheritDoc
      */
-    public function checkCondition(Condition $condition)
+    public function checkCondition(Condition $condition): bool
     {
         $attributes = [];
 

--- a/src/OperationEngine/Service/OperationServiceInterface.php
+++ b/src/OperationEngine/Service/OperationServiceInterface.php
@@ -37,7 +37,7 @@ interface OperationServiceInterface
 
     /**
      * @param Condition $condition
-     * @return mixed
+     * @return bool
      */
-    public function checkCondition(Condition $condition);
+    public function checkCondition(Condition $condition): bool;
 }


### PR DESCRIPTION
This PR adds selector classes which allow the conversation engine to retrieve conversation objects from the graph. Currently these are implemented in `ScenarioSelector`, `ConversationSelector`, `SceneSelector`, `TurnSelector` & `IntentSelector` classes.

The tests for the classes may look extensive but the reality is that (apart from the intent selector tests) they are very thin. The data client response is mocked and for the most part we're just testing that the conditions are filtering (with the condition filter having its own specific testcase). Whether these tests are even necessary was considered, but @patshone-gsl and I thought best to include something rather than nothing, and gives a place to expand the tests as functionality changes over time.

A key outcome of this PR is providing stubbed methods on the data client which indicate the requirements of future work there.