### PR TITLE
Incoming-outgoing intent matching: No-matching

### DIFF
--- a/src/ConversationEngine/ConversationEngine.php
+++ b/src/ConversationEngine/ConversationEngine.php
@@ -27,9 +27,8 @@ class ConversationEngine implements ConversationEngineInterface
 {
     public function getNextIntents(UtteranceAttribute $utterance): IntentCollection
     {
-        // We start by setting the request intent to a no match and the possible response intents
-        // to an empty collection. If all else fails this will be the default behavior.
-        $incomingIntent = Intent::createNoMatchIntent();
+        // We start by setting the possible response intents to an empty collection. If all else fails this will be the
+        // default behavior.
         $outgoingIntents = new IntentCollection();
 
         $currentUser = null;
@@ -43,7 +42,8 @@ class ConversationEngine implements ConversationEngineInterface
 
             $incomingIntent = IncomingIntentMatcher::matchIncomingIntent();
         } catch (NoMatchingIntentsException $e) {
-            Log::debug('No incoming intent matched, generating no-match intent');
+            Log::debug('No incoming intent matched.');
+            return new IntentCollection();
         }
 
         self::updateState($incomingIntent);

--- a/src/ConversationEngine/Reasoners/IncomingIntentMatcher.php
+++ b/src/ConversationEngine/Reasoners/IncomingIntentMatcher.php
@@ -43,7 +43,7 @@ class IncomingIntentMatcher
     public static function matchIncomingIntent(): Intent
     {
         if (ConversationContextUtil::currentConversationUid() == Conversation::UNDEFINED) {
-            // It's a non-ongoing conversation
+            // It's not an ongoing conversation
             try {
                 return self::matchNextIntentAsStartingRequestIntent();
             } catch (EmptyCollectionException $e) {

--- a/src/ConversationEngine/Reasoners/IncomingIntentMatcher.php
+++ b/src/ConversationEngine/Reasoners/IncomingIntentMatcher.php
@@ -4,7 +4,10 @@
 namespace OpenDialogAi\ConversationEngine\Reasoners;
 
 
-use Illuminate\Support\Facades\Log;
+use OpenDialogAi\AttributeEngine\CoreAttributes\UtteranceAttribute;
+use OpenDialogAi\ContextEngine\Contexts\BaseContexts\ConversationContext;
+use OpenDialogAi\ContextEngine\Contexts\User\UserContext;
+use OpenDialogAi\ContextEngine\Facades\ContextService;
 use OpenDialogAi\ConversationEngine\Exceptions\EmptyCollectionException;
 use OpenDialogAi\ConversationEngine\Exceptions\NoMatchingIntentsException;
 use OpenDialogAi\ConversationEngine\Facades\Selectors\ConversationSelector;
@@ -14,6 +17,7 @@ use OpenDialogAi\ConversationEngine\Facades\Selectors\SceneSelector;
 use OpenDialogAi\ConversationEngine\Facades\Selectors\TurnSelector;
 use OpenDialogAi\ConversationEngine\Util\ConversationContextUtil;
 use OpenDialogAi\Core\Conversation\Conversation;
+use OpenDialogAi\Core\Conversation\ConversationObject;
 use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\Scenario;
 use OpenDialogAi\Core\Conversation\ScenarioCollection;
@@ -23,6 +27,11 @@ use OpenDialogAi\Core\Conversation\TurnCollection;
 
 class IncomingIntentMatcher
 {
+    const GLOBAL_NO_MATCH_INTENT_ID = 'intent.core.NoMatch';
+    const TURN_NO_MATCH_INTENT_ID = 'intent.core.TurnNoMatch';
+    const SCENE_NO_MATCH_INTENT_ID = 'intent.core.SceneNoMatch';
+    const CONVERSATION_NO_MATCH_INTENT_ID = 'intent.core.ConversationNoMatch';
+
     /**
      * Returns a single matching incoming intent, determined by the utterance and conversation context. Depending on
      * whether the user is in an ongoing conversation, and whether the user is in a turn request or turn response, will
@@ -33,11 +42,17 @@ class IncomingIntentMatcher
      */
     public static function matchIncomingIntent(): Intent
     {
-        try {
-            if (ConversationContextUtil::currentConversationUid() == Conversation::UNDEFINED) {
-                // It's a non-ongoing conversation
+        if (ConversationContextUtil::currentConversationUid() == Conversation::UNDEFINED) {
+            // It's a non-ongoing conversation
+            try {
                 return self::matchNextIntentAsStartingRequestIntent();
-            } else {
+            } catch (EmptyCollectionException $e) {
+                // No matching
+                self::prepareContextForStartingRequestGlobalNoMatch();
+                return self::matchIncomingIntent();
+            }
+        } else {
+            try {
                 // It's an ongoing conversation
                 if (ConversationContextUtil::currentIntentIsRequest()) {
                     // if "current" intent (at this point the current data is actually the previous data) is a request it
@@ -46,10 +61,11 @@ class IncomingIntentMatcher
                 } else {
                     return self::matchNextIntentAsRequestIntent();
                 }
+            } catch (EmptyCollectionException $e) {
+                // No matching
+                self::prepareContextForOngoingNoMatches();
+                return self::matchIncomingIntent();
             }
-        } catch (EmptyCollectionException $e) {
-            Log::debug('No incoming intent selected');
-            throw new NoMatchingIntentsException();
         }
     }
 
@@ -123,5 +139,69 @@ class IncomingIntentMatcher
 
         // Finally out of all the matching intents select the one with the highest confidence.
         return IntentRanker::getTopRankingIntent($intents);
+    }
+
+    /**
+     * @throws NoMatchingIntentsException
+     */
+    private static function prepareContextForStartingRequestGlobalNoMatch(): void
+    {
+        /** @var UtteranceAttribute $utterance */
+        $utterance = ContextService::getAttribute(UtteranceAttribute::UTTERANCE, UserContext::USER_CONTEXT);
+
+        if ($utterance->getCallbackId() === self::GLOBAL_NO_MATCH_INTENT_ID) {
+            // Even the no-match intent didn't match, quitting (base case)
+            throw new NoMatchingIntentsException();
+        } elseif ($utterance->getCallbackId() === self::CONVERSATION_NO_MATCH_INTENT_ID) {
+            // Conversation no-match intent didn't match, trying global no-match intent
+            ContextService::saveAttribute(
+                ConversationContext::getComponentId() . '.' . Conversation::CURRENT_CONVERSATION,
+                ConversationObject::UNDEFINED
+            );
+        }
+
+        $utterance->setUtteranceAttribute(UtteranceAttribute::CALLBACK_ID, self::GLOBAL_NO_MATCH_INTENT_ID);
+
+        ContextService::saveAttribute(
+            UserContext::USER_CONTEXT . '.' . UtteranceAttribute::UTTERANCE,
+            $utterance
+        );
+    }
+
+    /**
+     * Allows for progressively escalating no-matching from turn no-match, to scene no-match, to conversation no-match,
+     * to a global no-match.
+     *
+     * @throws NoMatchingIntentsException
+     */
+    private static function prepareContextForOngoingNoMatches(): void
+    {
+        /** @var UtteranceAttribute $utterance */
+        $utterance = ContextService::getAttribute(UtteranceAttribute::UTTERANCE, UserContext::USER_CONTEXT);
+
+        if ($utterance->getCallbackId() === self::TURN_NO_MATCH_INTENT_ID) {
+            // Turn no-match intent didn't match, trying scene no-match intent
+            $intentId = self::SCENE_NO_MATCH_INTENT_ID;
+            ContextService::saveAttribute(
+                ConversationContext::getComponentId() . '.' . Intent::INTENT_IS_REQUEST,
+                false
+            );
+        } elseif ($utterance->getCallbackId() === self::SCENE_NO_MATCH_INTENT_ID) {
+            // Scene no-match intent didn't match, trying conversation no-match intent
+            $intentId = self::CONVERSATION_NO_MATCH_INTENT_ID;
+            ContextService::saveAttribute(
+                ConversationContext::getComponentId() . '.' . Conversation::CURRENT_CONVERSATION,
+                ConversationObject::UNDEFINED
+            );
+        } else {
+            // First try turn no-match intent
+            $intentId = self::TURN_NO_MATCH_INTENT_ID;
+        }
+
+        $utterance->setUtteranceAttribute(UtteranceAttribute::CALLBACK_ID, $intentId);
+        ContextService::saveAttribute(
+            UserContext::USER_CONTEXT . '.' . UtteranceAttribute::UTTERANCE,
+            $utterance
+        );
     }
 }

--- a/src/ConversationEngine/Tests/IncomingIntentMatcherTest.php
+++ b/src/ConversationEngine/Tests/IncomingIntentMatcherTest.php
@@ -413,8 +413,11 @@ class IncomingIntentMatcherTest extends TestCase
             );
 
         TurnSelector::shouldReceive('selectTurnsByValidOrigin')
-            ->once()
-            ->andReturn(new TurnCollection());
+            ->twice()
+            ->andReturn(
+                new TurnCollection(),
+                new TurnCollection(),
+            );
 
         $intents = new IntentCollection();
 
@@ -456,8 +459,12 @@ class IncomingIntentMatcherTest extends TestCase
             );
 
         TurnSelector::shouldReceive('selectTurnsByValidOrigin')
-            ->once()
-            ->andReturn(new TurnCollection());
+            ->times(3)
+            ->andReturn(
+                new TurnCollection(),
+                new TurnCollection(),
+                new TurnCollection()
+            );
 
         $intents = new IntentCollection();
 
@@ -487,6 +494,14 @@ class IncomingIntentMatcherTest extends TestCase
     {
         $scene = $this->createScene();
 
+        SceneSelector::shouldReceive('selectSceneById')
+            ->times(3)
+            ->andReturn(
+                $scene,
+                $scene,
+                $scene
+            );
+
         $turn = new Turn($scene);
         $turn->setBehaviors(new BehaviorsCollection([new Behavior(Behavior::OPEN_BEHAVIOR)]));
         $turn->setODId(self::TEST_TURN_2);
@@ -500,8 +515,12 @@ class IncomingIntentMatcherTest extends TestCase
             );
 
         TurnSelector::shouldReceive('selectTurnsByValidOrigin')
-            ->once()
-            ->andReturn(new TurnCollection());
+            ->times(3)
+            ->andReturn(
+                new TurnCollection(),
+                new TurnCollection(),
+                new TurnCollection()
+            );
 
         $intents = new IntentCollection();
 
@@ -525,9 +544,9 @@ class IncomingIntentMatcherTest extends TestCase
         $scenario = new Scenario();
         $scenario->setODId(self::TEST_SCENARIO_1);
 
-        ScenarioSelector::shouldReceive('selectScenarios')
+        ScenarioSelector::shouldReceive('selectScenarioById')
             ->once()
-            ->andReturn(new ScenarioCollection([$scenario]));
+            ->andReturn($scenario);
 
         $conversation = new Conversation();
         $conversation->setODId(self::TEST_CONVERSATION_1);
@@ -547,6 +566,7 @@ class IncomingIntentMatcherTest extends TestCase
             ->once()
             ->andReturn(new TurnCollection([$turn]));
 
+
         return $noMatchIntent;
     }
 
@@ -556,6 +576,14 @@ class IncomingIntentMatcherTest extends TestCase
     private function mockSelectorsForIncomingOngoingGlobalNoMatchRequest(): Intent
     {
         $scene = $this->createScene();
+
+        SceneSelector::shouldReceive('selectSceneById')
+            ->times(3)
+            ->andReturn(
+                $scene,
+                $scene,
+                $scene
+            );
 
         $turn = new Turn($scene);
         $turn->setBehaviors(new BehaviorsCollection([new Behavior(Behavior::OPEN_BEHAVIOR)]));
@@ -570,8 +598,12 @@ class IncomingIntentMatcherTest extends TestCase
             );
 
         TurnSelector::shouldReceive('selectTurnsByValidOrigin')
-            ->once()
-            ->andReturn(new TurnCollection());
+            ->times(3)
+            ->andReturn(
+                new TurnCollection(),
+                new TurnCollection(),
+                new TurnCollection()
+            );
 
         $intents = new IntentCollection();
 
@@ -584,7 +616,7 @@ class IncomingIntentMatcherTest extends TestCase
         $intents->addObject($noMatchIntent);
 
         IntentSelector::shouldReceive('selectRequestIntents')
-            ->times(4)
+            ->times(5)
             ->andReturn(
                 new IntentCollection(),
                 new IntentCollection(),
@@ -596,27 +628,39 @@ class IncomingIntentMatcherTest extends TestCase
         $scenario = new Scenario();
         $scenario->setODId(self::TEST_SCENARIO_1);
 
-        ScenarioSelector::shouldReceive('selectScenarios')
+        ScenarioSelector::shouldReceive('selectScenarioById')
             ->twice()
-            ->andReturn(new ScenarioCollection([$scenario]));
+            ->andReturn(
+                $scenario,
+                $scenario
+            );
 
         $conversation = new Conversation();
         $conversation->setODId(self::TEST_CONVERSATION_1);
         ConversationSelector::shouldReceive('selectStartingConversations')
             ->twice()
-            ->andReturn(new ConversationCollection([$conversation]));
+            ->andReturn(
+                new ConversationCollection([$conversation]),
+                new ConversationCollection([$conversation])
+            );
 
         $scene = new Scene();
         $scene->setODId(self::TEST_SCENE_1);
         SceneSelector::shouldReceive('selectStartingScenes')
             ->twice()
-            ->andReturn(new SceneCollection([$scene]));
+            ->andReturn(
+                new SceneCollection([$scene]),
+                new SceneCollection([$scene]),
+            );
 
         $turn = new Turn();
         $turn->setODId(self::TEST_TURN_1);
         TurnSelector::shouldReceive('selectStartingTurns')
             ->twice()
-            ->andReturn(new TurnCollection([$turn]));
+            ->andReturn(
+                new TurnCollection([$turn]),
+                new TurnCollection([$turn]),
+            );
 
         return $noMatchIntent;
     }

--- a/src/ConversationEngine/Tests/IncomingIntentMatcherTest.php
+++ b/src/ConversationEngine/Tests/IncomingIntentMatcherTest.php
@@ -100,7 +100,7 @@ class IncomingIntentMatcherTest extends TestCase
         $this->assertSame($desiredIntent, IncomingIntentMatcher::matchIncomingIntent());
     }
 
-    public function testNoMatchNoOngoingConversation()
+    public function testGlobalNoMatchNoOngoingConversation()
     {
         // Mock selectors, no intents should match
         $noMatchIntent = new Intent();


### PR DESCRIPTION
This PR implements functionality for when an incoming intent can not be matched. It's worth noting that ultimately if an incoming, or outgoing, intent can not be matched an empty intent collection will be returned (leaving us open to consider the best way to let the user know that something has gone wrong). In the case of incoming intents we have a desired process to attempt before this point however. This process breaks down as so.

**If the user is not in an ongoing conversation**:

1. Update the utterance's callback ID to `intent.core.NoMatch` and re-run incoming intent matching.

**If the user is in an ongoing conversation**:

1. Update the utterance's callback ID to `intent.core.TurnNoMatch` and re-run incoming intent matching.
2. Update the utterance's callback ID to `intent.core.SceneNoMatch` and re-run incoming intent matching.
3. Update the utterance's callback ID to `intent.core.ConversationNoMatch`, unset the user's current conversation and re-run incoming intent matching.
4. Update the utterance's callback ID to `intent.core.NoMatch`, unset the user's current conversation and re-run incoming intent matching.